### PR TITLE
feat: Add invoice checkpoint logic and update invoice item processing

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
@@ -292,9 +292,10 @@ def process_invoice_items(
                 "Item", "name", item.get("item_code"), "custom_slade_id"
             ),
             "quantity": round(abs(item.get("qty")), 2),
-            "new_price": item.get("rate")
+            "new_price": item.get("net_rate")
             + (abs(item.get("custom_tax_amount", 0)) / abs(item.get("qty"))),
-            "amount": abs(item.get("amount")) + abs(item.get("custom_tax_amount", 0)),
+            "amount": abs(item.get("net_amount"))
+            + abs(item.get("custom_tax_amount", 0)),
             "credit_note" if invoice.is_return else "sales_invoice": invoice_slade_id,
             "document_name": item.get("name"),
             "allow_discount": False,

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
@@ -21,7 +21,7 @@ frappe.ui.form.on(parentDoctype, {
     );
 
     if (activeSetting?.name) {
-      if (!frm.doc.custom_slade_id) {
+      if (!frm.doc.custom_successfully_submitted) {
         frm.add_custom_button(
           __("Send Invoice"),
           function () {

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/shared_overrides.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/shared_overrides.py
@@ -56,6 +56,31 @@ def generic_invoices_on_submit_override(
             )
             return
 
+    # Check if custom_slade_id exists
+    if doc.custom_slade_id:
+        # If custom_slade_id exists, start from process_invoice_items
+        frappe.enqueue(
+            "kenya_compliance_via_slade.kenya_compliance_via_slade.apis.remote_response_status_handlers.process_invoice_items",
+            document_name=doc.name,
+            doctype=invoice_type,
+            invoice_slade_id=doc.custom_slade_id,
+            queue="long",
+        )
+        return
+
+    # Check if custom_transition_successful exists
+    if doc.custom_transition_successful:
+        # If custom_transition_successful exists, start from process_sales_sign
+        frappe.enqueue(
+            "kenya_compliance_via_slade.kenya_compliance_via_slade.apis.remote_response_status_handlers.process_sales_sign",
+            document_name=doc.name,
+            doctype=invoice_type,
+            invoice_slade_id=doc.custom_slade_id,
+            queue="long",
+        )
+        return
+
+    # If neither custom_slade_id nor custom_transition_successful exists, proceed with the normal flow
     payload = build_invoice_payload(doc, company_name, doc.is_return)
     additional_context = {
         "invoice_type": invoice_type,


### PR DESCRIPTION
- Added checkpoint logic to `generic_invoices_on_submit_override`:
  - Resumes from `process_invoice_items` if `custom_slade_id` exists.
  - Resumes from `process_sales_sign` if `custom_transition_successful` exists.
  - Ensures seamless continuation and reduces redundant API calls.

- Updated `process_invoice_items`:
  - Uses `net_rate` and `net_amount` for accurate tax and discount calculations.
  - Supports `PATCH` requests for items with `custom_slade_id`.