### PR TITLE
fix: update links in documentation for correct relative paths

### DIFF
--- a/kenya_compliance_via_slade/docs/doctypes.md
+++ b/kenya_compliance_via_slade/docs/doctypes.md
@@ -2,19 +2,19 @@
 
 Here are the key DocTypes included in the system:
 
-## ⚙️ [Environment Settings](doctypes/environment_settings.md)
+## ⚙️ [Environment Settings](./doctypes/environment_settings.md)
 
 **Operation: Configuration**
 
 This DocType aggregates all the settings and credentials required for communication with the eTims Servers.
 
-## 🔗 [Routes Reference](doctypes/routes_reference.md)
+## 🔗 [Routes Reference](./doctypes/routes_reference.md)
 
 **Operation: Reference Management**
 
 This DocType holds references to Slade 360's endpoints for various activities, maintaining last request timestamps.
 
-## 🗂️ [Operation Type](doctypes/operation_type.md)
+## 🗂️ [Operation Type](./doctypes/operation_type.md)
 
 **Operation: Stock Operations Only**
 
@@ -22,4 +22,4 @@ Manages stock operations for submitting stock to Slade 360, ensuring proper mapp
 
 ---
 
-[⬅️ Previous: Key Features](./features.md) | [Next: Environment Settings ➡️](environment_settings.md)
+[⬅️ Previous: Key Features](./features.md) | [Next: Customisations ➡️](./customisations.md)

--- a/kenya_compliance_via_slade/docs/features.md
+++ b/kenya_compliance_via_slade/docs/features.md
@@ -88,7 +88,7 @@ BOMs are submitted after they are submitted or through manual submission.
 
 ![Registered Purchases Screenshot](./images/registered_purchases.png)
 
-The Registered Purchases feature allows users to fetch all purchases from eTims and generate related invoices in ERPNext with the associated suppliers and items. More detailed information on [Registered Purchases](./registered_purchases.md).
+The Registered Purchases feature allows users to fetch all purchases from eTims and generate related invoices in ERPNext with the associated suppliers and items. More detailed information on [Registered Purchases](./features/registered_purchases.md).
 
 ### 🌐 Imports Fetch
 
@@ -96,6 +96,6 @@ The Registered Purchases feature allows users to fetch all purchases from eTims 
 
 ![Imports Fetch Screenshot](./images/imports_fetch.png)
 
-The Imports Fetch feature enables users to fetch and manage imported goods data from eTims. This includes mapping the imported items. More detailed information on [Imports Fetch](./imports_fetch.md).
+The Imports Fetch feature enables users to fetch and manage imported goods data from eTims. This includes mapping the imported items. More detailed information on [Imports Fetch](./features/imports_fetch.md).
 
-[⬅️ Previous: Setup Configuration](./setup_configuration.md) | [Next: Customisations ➡️](./customisations.md)
+[⬅️ Previous: Setup Configuration](./setup_configuration.md) | [Next: Key Doctypes ➡️](./doctypes.md)

--- a/kenya_compliance_via_slade/docs/setup_configuration.md
+++ b/kenya_compliance_via_slade/docs/setup_configuration.md
@@ -8,11 +8,11 @@ To set up the application, follow these steps:
 
 1. **🛠️ Create the eTims Settings**:
 
-   Navigate to the eTims Settings doctype and create a new record with the necessary details. [Learn more](settings_configuration.md)
+   Navigate to the eTims Settings doctype and create a new record with the necessary details. [Learn more](./doctypes/environment_settings.md)
 
 2. **🔄 Fetch All Codes**:
 
-   In the eTims Settings doctype, click the _Get Codes_ button to fetch the latest codes from the eTims servers. [Learn more](settings_configuration.md)
+   In the eTims Settings doctype, click the _Get Codes_ button to fetch the latest codes from the eTims servers. [Learn more](./doctypes/environment_settings.md)
 
 3. **🔗 Sync the Organisation Structures**:
 
@@ -28,7 +28,7 @@ To set up the application, follow these steps:
 
 6. **📦 Classify and Register All Items**:
 
-   Navigate to the Item list view and classify each item according to the specifications provided by KRA and submit to eTims. [Learn more](item_actions.md)
+   Navigate to the Item list view and classify each item according to the specifications provided by KRA and submit to eTims. [Learn more](./features/item_registration.md)
 
 By following these steps, you will ensure that your application is properly set up and ready to communicate with the eTims servers.
 


### PR DESCRIPTION
This pull request includes updates to documentation in the `kenya_compliance_via_slade` directory, primarily focusing on updating relative links for consistency and accuracy. These changes ensure that links point to the correct files and maintain a uniform structure across the documentation.

### Updates to relative links:

* **DocTypes Documentation**: Updated links in `doctypes.md` to use a consistent `./` prefix format for relative paths, ensuring proper navigation. Additionally, the "Next" link at the bottom now points to `customisations.md` instead of `environment_settings.md`.

* **Feature Details**: Adjusted links in `features.md` to ensure feature-specific pages like "Registered Purchases" and "Imports Fetch" point to their respective files within the `features` subdirectory. The "Next" link now points to `doctypes.md` instead of `customisations.md`.

* **Setup Configuration**: 
  - Updated links in `setup_configuration.md` to point to the correct files, such as `environment_settings.md` under the `doctypes` subdirectory for eTims settings.
  - Changed the link for item classification to point to `item_registration.md` under the `features` subdirectory.