### PR TITLE
fix: Use correct field of tax_id to get the value(change from customer_pin to tax_id) while registering Customer

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/apis.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/apis.py
@@ -276,7 +276,7 @@ def send_branch_customer_details(name: str, is_customer: bool = True) -> None:
         payload.update(
             {
                 "is_customer": True,
-                "customer_tax_pin": data.get("customer_tax_pin"),
+                "customer_tax_pin": data.get("tax_id"),
                 "partner_name": data.get("customer_name"),
                 "phone_number": data.get("mobile_no"),
                 "customer_type": mapped_customer_type,


### PR DESCRIPTION

Before, when we have pin on the customer doctype
![Screenshot 2025-04-26 at 16 25 14](https://github.com/user-attachments/assets/8a5e3a4c-7056-44e2-8cfa-9824f8e392ad)
Then when you check the payload on integration request
![Screenshot 2025-04-26 at 16 26 21](https://github.com/user-attachments/assets/4b0d97e0-6a1a-4377-b25f-66f1e76af135)


After the changes, here is the payload.
![Screenshot 2025-04-26 at 16 27 44](https://github.com/user-attachments/assets/57513a32-60d1-43ec-9f81-5f43fa269aa9)


