### PR TITLE
fix: update invoice payload structure for return and regular invoices

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -358,7 +358,7 @@ def build_invoice_payload(
         # RETURN INVOICE STRUCTURE
         payload = {
             "document_name": invoice.name,
-            "invoice_reference": clean_invc_no(invoice.return_against) if invoice.amended_from else invoice.return_against,
+            "invoice_reference": invoice.return_against,
             "refund_reason": "13",  # Assuming standard reason code
             "amount": abs(invoice.base_grand_total),
             "items": []
@@ -381,8 +381,8 @@ def build_invoice_payload(
         # REGULAR INVOICE STRUCTURE
         payload = {
             "document_name": invoice.name,
-            "reference_number": clean_invc_no(invoice.name) if invoice.amended_from else invoice.name,
-            "sales_type": "",
+            "reference_number": invoice.name,
+            "sales_type": "credit",
             "customer_pin": frappe.get_value("Customer", invoice.customer, "tax_id") or "None",
             "itemDetails": []
         }


### PR DESCRIPTION

This pull request simplifies and enhances the `build_invoice_payload` function in `kenya_compliance_via_slade/utils.py` to improve invoice reference handling and ensure consistent sales type definition.

---

### 🔄 Changes to Invoice Reference Handling

- 🧹 **Removed redundant logic**: The `clean_invc_no` logic has been removed.
- ➕ **Simplified reference fields**:
  - `invoice_reference` now directly uses `invoice.return_against`.
  - `reference_number` now directly uses `invoice.name`.

🔗 [[[Ref 1]](diffhunk://#diff-49f2f650dc9c4dd5f1c270e16a00dad0a48d0ac96ca7a22679b9c93272498ac6L361-R361)](diffhunk://#diff-49f2f650dc9c4dd5f1c270e16a00dad0a48d0ac96ca7a22679b9c93272498ac6L361-R361)  
🔗 [[[Ref 2]](diffhunk://#diff-49f2f650dc9c4dd5f1c270e16a00dad0a48d0ac96ca7a22679b9c93272498ac6L384-R385)](diffhunk://#diff-49f2f650dc9c4dd5f1c270e16a00dad0a48d0ac96ca7a22679b9c93272498ac6L384-R385)

---

### ⚙️ Enhancements to Regular Invoice Payload

- 🆕 **Default Sales Type**: Set `sales_type` to `"credit"` by default in the regular invoice payload.
- 🔁 **Code consistency**: Reduces branching logic and ensures return and regular invoices are clearly separated and handled.

---

### ✅ Benefits

- ✨ Cleaner and more maintainable logic.
- 🧾 More accurate and consistent invoice reference data.
- 🧩 Sets groundwork for improved downstream processing.

---

### 🔧 Fixes

Closes #123
