### PR TITLE
fix: update invoice payload to use item codes instead of item names

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -372,7 +372,7 @@ def build_invoice_payload(
             qty = abs(item.get("qty"))
             base_amount = round(abs(item.get("base_amount")) or 0, 4)
             payload["items"].append({
-                "item_name": item.item_name,
+                "item_name": item.item_code,
                 "quantity": qty,
                 "amount": round(base_amount + converted_tax_amount, 4),
             })
@@ -396,7 +396,7 @@ def build_invoice_payload(
             base_net_rate = round(item.get("base_net_rate") or 0, 4)
             tax_code = (item.item_tax_template and frappe.get_value("Tax Template", item.item_tax_template, "custom_etims_taxation_type")) or frappe.get_value("Item", item.item_code, "custom_taxation_type")
             payload["itemDetails"].append({
-                "product_name": item.item_name,
+                "product_name": item.item_code,
                 "unit_price": round(base_net_rate + (converted_tax_amount / qty if qty else 0), 4),
                 "discount": item.discount_amount or 0,
                 "quantity": qty,


### PR DESCRIPTION
This pull request modifies the `build_invoice_payload` function in the `kenya_compliance_via_slade/utils.py` file to improve the accuracy and consistency of item references in the invoice payload. The key changes involve replacing `item_name` with `item_code` in multiple places to ensure the correct identification of items.

### Updates to item references in the payload:

* Replaced `item_name` with `item_code` for the `item_name` key in the `payload["items"]` dictionary to ensure accurate item identification. (`[kenya_compliance_via_slade/kenya_compliance_via_slade/utils.pyL375-R375](diffhunk://#diff-49f2f650dc9c4dd5f1c270e16a00dad0a48d0ac96ca7a22679b9c93272498ac6L375-R375)`)
* Replaced `item_name` with `item_code` for the `product_name` key in the `payload["itemDetails"]` dictionary to maintain consistency with other item references. (`[kenya_compliance_via_slade/kenya_compliance_via_slade/utils.pyL399-R399](diffhunk://#diff-49f2f650dc9c4dd5f1c270e16a00dad0a48d0ac96ca7a22679b9c93272498ac6L399-R399)`)