### PR TITLE
Invoice Tax Calculation and Codebase Enhancements

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/apis.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/apis.py
@@ -125,7 +125,7 @@ def perform_customer_search(request_data: str) -> None:
 def perform_item_registration(item_name: str) -> dict | None:
     item = frappe.get_doc("Item", item_name)
 
-    if item.custom_prevent_etims_registration:
+    if item.custom_prevent_etims_registration or item.disabled:
         return
 
     missing_fields = []

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
@@ -76,11 +76,14 @@ def item_registration_on_success(response: dict, document_name: str, **kwargs) -
         "custom_sent_to_slade": 1,
     }
     frappe.db.set_value("Item", document_name, updates)
-    frappe.enqueue(
-        "kenya_compliance_via_slade.kenya_compliance_via_slade.apis.apis.submit_inventory",
-        name=document_name,
-        queue="long",
-    )
+
+    item_doc = frappe.get_doc("Item", document_name)
+    if item_doc.maintain_stock:
+        frappe.enqueue(
+            "kenya_compliance_via_slade.kenya_compliance_via_slade.apis.apis.submit_inventory",
+            name=document_name,
+            queue="long",
+        )
 
 
 def customer_branch_details_submission_on_success(

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
@@ -14,6 +14,7 @@ frappe.realtime.on("refresh_form", function (name) {
 
 frappe.ui.form.on(parentDoctype, {
   refresh: async function (frm) {
+    await updateTaxAmountLabel(frm);
     const { message: activeSetting } = await frappe.db.get_value(
       settingsDoctypeName,
       { is_active: 1 },
@@ -148,3 +149,28 @@ frappe.ui.form.on(childDoctype, {
     }
   },
 });
+
+async function updateTaxAmountLabel(frm) {
+  try {
+    const defaultCompany = frappe.defaults.get_user_default("Company");
+    if (!defaultCompany) return;
+
+    const { message: companyDoc } = await frappe.db.get_value(
+      "Company",
+      defaultCompany,
+      "default_currency"
+    );
+
+    if (companyDoc?.default_currency) {
+      const currency = companyDoc.default_currency;
+
+      frm.fields_dict.items.grid.update_docfield_property(
+        "custom_tax_amount",
+        "label",
+        `Tax Amount (${currency})`
+      );
+    }
+  } catch (error) {
+    console.error("Error updating Tax Amount label:", error);
+  }
+}

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/sales_invoice.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/sales_invoice.py
@@ -2,6 +2,7 @@ import frappe
 from frappe.model.document import Document
 
 from .shared_overrides import generic_invoices_on_submit_override
+from ...utils import calculate_tax
 
 
 def on_submit(doc: Document, method: str = None) -> None:
@@ -11,6 +12,7 @@ def on_submit(doc: Document, method: str = None) -> None:
         and doc.custom_defer_etims_submission == 0
         and doc.is_opening == "No"
     ):
+        calculate_tax(doc)
         generic_invoices_on_submit_override(doc, "Sales Invoice")
 
 

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/bom.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/bom.py
@@ -1,5 +1,0 @@
-from .create_fields_from_json import create_fields_from_json
-
-
-def execute() -> None:
-    create_fields_from_json("./custom_fields/bom.json", "BOM")

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/bom_item.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/bom_item.py
@@ -1,5 +1,0 @@
-from .create_fields_from_json import create_fields_from_json
-
-
-def execute() -> None:
-    create_fields_from_json("./custom_fields/bom_item.json", "BOM Item")

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/branch.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/branch.py
@@ -1,5 +1,0 @@
-from .create_fields_from_json import create_fields_from_json
-
-
-def execute() -> None:
-    create_fields_from_json("./custom_fields/branch.json", "Branch")

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/company.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/company.py
@@ -1,5 +1,0 @@
-from .create_fields_from_json import create_fields_from_json
-
-
-def execute() -> None:
-    create_fields_from_json("./custom_fields/company.json", "Company")

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/create_connection_links.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/create_connection_links.py
@@ -11,26 +11,29 @@ def update_links_for_doctypes() -> None:
         "Supplier"
     ]
     for doctype in doctypes:
-        doc = frappe.get_doc("DocType", doctype)
+        try:
+            doc = frappe.get_doc("DocType", doctype)
 
-        # Filter out existing links to Integration Request
-        doc.links = [
+            # Filter out existing links to Integration Request
+            doc.links = [
             link for link in doc.get("links", [])
             if link.link_doctype != "Integration Request"
-        ]
+            ]
 
-        # Add fresh Integration Request link
-        doc.append(
+            # Add fresh Integration Request link
+            doc.append(
             "links",
             {
                 "link_doctype": "Integration Request",
                 "group": "Integration Request",
                 "link_fieldname": "reference_docname",
             },
-        )
+            )
 
-        doc.save()
-        frappe.db.commit()
+            doc.save()
+            frappe.db.commit()
+        except Exception as e:
+            frappe.log_error(message=f"Error updating links for {doctype}: {str(e)}", title="Update Links Error")
 
 def execute() -> None:
     update_links_for_doctypes()

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/create_fields_from_json.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/create_fields_from_json.py
@@ -28,7 +28,12 @@ def create_fields_from_json(json_file_name: str, doctype: str) -> None:
 
     except Exception as e:
         frappe.log_error(
-            f"Error in creating custom fields for {doctype}: {str(e)}",
             "Custom Field Creation Error",
+            f"Error in creating custom fields for {doctype}: {str(e)}",
         )
-        raise e
+        # raise e
+        
+        
+        
+        
+        

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/currency.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/currency.py
@@ -1,5 +1,0 @@
-from .create_fields_from_json import create_fields_from_json
-
-
-def execute() -> None:
-    create_fields_from_json("./custom_fields/currency.json", "Currency")

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/custom_fields/sales_invoice_item.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/custom_fields/sales_invoice_item.json
@@ -41,7 +41,8 @@
     "fieldname": "custom_tax_amount",
     "fieldtype": "Currency",
     "insert_after": "custom_tax_rate",
-    "label": "Tax Amount",
+    "label": "Tax Amount (Company Currency)",
+    "options": "Company:company:default_currency",
     "name": "Sales Invoice Item-custom_tax_amount"
   }
 ]

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/customer.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/customer.py
@@ -1,5 +1,0 @@
-from .create_fields_from_json import create_fields_from_json
-
-
-def execute() -> None:
-    create_fields_from_json("./custom_fields/customer.json", "Customer")

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/department.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/department.py
@@ -1,5 +1,0 @@
-from .create_fields_from_json import create_fields_from_json
-
-
-def execute() -> None:
-    create_fields_from_json("./custom_fields/department.json", "Department")

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/item.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/item.py
@@ -1,5 +1,0 @@
-from .create_fields_from_json import create_fields_from_json
-
-
-def execute() -> None:
-    create_fields_from_json("./custom_fields/item.json", "Item")

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/item_tax_template.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/item_tax_template.py
@@ -1,7 +1,0 @@
-from .create_fields_from_json import create_fields_from_json
-
-
-def execute() -> None:
-    create_fields_from_json(
-        "./custom_fields/item_tax_template.json", "Item Tax Template"
-    )

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/mode_of_payment.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/mode_of_payment.py
@@ -1,5 +1,0 @@
-from .create_fields_from_json import create_fields_from_json
-
-
-def execute() -> None:
-    create_fields_from_json("./custom_fields/mode_of_payment.json", "Mode of Payment")

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/purchase_invoice.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/purchase_invoice.py
@@ -1,5 +1,0 @@
-from .create_fields_from_json import create_fields_from_json
-
-
-def execute() -> None:
-    create_fields_from_json("./custom_fields/purchase_invoice.json", "Purchase Invoice")

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/purchase_invoice_item.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/purchase_invoice_item.py
@@ -1,7 +1,0 @@
-from .create_fields_from_json import create_fields_from_json
-
-
-def execute() -> None:
-    create_fields_from_json(
-        "./custom_fields/purchase_invoice_item.json", "Purchase Invoice Item"
-    )

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/sales_invoice.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/sales_invoice.py
@@ -1,5 +1,0 @@
-from .create_fields_from_json import create_fields_from_json
-
-
-def execute() -> None:
-    create_fields_from_json("./custom_fields/sales_invoice.json", "Sales Invoice")

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/sales_invoice_item.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/sales_invoice_item.py
@@ -1,7 +1,0 @@
-from .create_fields_from_json import create_fields_from_json
-
-
-def execute() -> None:
-    create_fields_from_json(
-        "./custom_fields/sales_invoice_item.json", "Sales Invoice Item"
-    )

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/stock_ledger_entry.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/stock_ledger_entry.py
@@ -1,7 +1,0 @@
-from .create_fields_from_json import create_fields_from_json
-
-
-def execute() -> None:
-    create_fields_from_json(
-        "./custom_fields/stock_ledger_entry.json", "Stock Ledger Entry"
-    )

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/supplier.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/supplier.py
@@ -1,5 +1,0 @@
-from .create_fields_from_json import create_fields_from_json
-
-
-def execute() -> None:
-    create_fields_from_json("./custom_fields/supplier.json", "Supplier")

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/warehouse.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/warehouse.py
@@ -1,5 +1,0 @@
-from .create_fields_from_json import create_fields_from_json
-
-
-def execute() -> None:
-    create_fields_from_json("./custom_fields/warehouse.json", "Warehouse")

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -364,17 +364,17 @@ def build_invoice_payload(
             "items": []
         }
         
-        conversion_rate = invoice.conversion_rate or 1
+        # conversion_rate = invoice.conversion_rate or 1
         
         for item in invoice.items:
             tax_amount = item.get("custom_tax_amount", 0) or 0
-            converted_tax_amount = round(tax_amount * conversion_rate, 4) if tax_amount else 0
+            # converted_tax_amount = round(tax_amount * conversion_rate, 4) if tax_amount else 0
             qty = abs(item.get("qty"))
             base_amount = round(abs(item.get("base_amount")) or 0, 4)
             payload["items"].append({
                 "item_name": item.item_code,
                 "quantity": qty,
-                "amount": round(base_amount + converted_tax_amount, 4),
+                "amount": round(base_amount + tax_amount, 4),
             })
     
     else:
@@ -387,17 +387,17 @@ def build_invoice_payload(
             "itemDetails": []
         }
         
-        conversion_rate = invoice.conversion_rate or 1
+        # conversion_rate = invoice.conversion_rate or 1
         
         for item in invoice.items:
             tax_amount = item.get("custom_tax_amount", 0) or 0
-            converted_tax_amount = round(tax_amount * conversion_rate, 4) if tax_amount else 0
+            # converted_tax_amount = round(tax_amount * conversion_rate, 4) if tax_amount else 0
             qty = abs(item.get("qty"))
             base_net_rate = round(item.get("base_net_rate") or 0, 4)
-            tax_code = (item.item_tax_template and frappe.get_value("Tax Template", item.item_tax_template, "custom_etims_taxation_type")) or frappe.get_value("Item", item.item_code, "custom_taxation_type")
+            tax_code = (item.item_tax_template and frappe.get_value("Item Tax Template", item.item_tax_template, "custom_etims_taxation_type")) or frappe.get_value("Item", item.item_code, "custom_taxation_type")
             payload["itemDetails"].append({
                 "product_name": item.item_code,
-                "unit_price": round(base_net_rate + (converted_tax_amount / qty if qty else 0), 4),
+                "unit_price": round(base_net_rate + (tax_amount / qty if qty else 0), 4),
                 "discount": item.discount_amount or 0,
                 "quantity": qty,
                 "uom": item.uom or "Pcs",
@@ -641,7 +641,7 @@ def calculate_tax(doc: "Document") -> None:
 
         # Calculate tax if we have a valid tax rate
         if tax_rate is not None:
-            tax = item.net_amount * tax_rate / 100
+            tax = item.base_net_amount * tax_rate / 100
 
         # Set the custom tax fields in the item
         item.custom_tax_amount = tax
@@ -649,10 +649,10 @@ def calculate_tax(doc: "Document") -> None:
 
 
 def get_item_tax_rate(item_tax_template: str) -> float | None:
-    """Fetch the tax rate from the Item Tax Template."""
+    """Fetch the combined tax rate from the Item Tax Template."""
     tax_template = frappe.get_doc("Item Tax Template", item_tax_template)
     if tax_template.taxes:
-        return tax_template.taxes[0].tax_rate
+        return sum(tax.tax_rate for tax in tax_template.taxes)
     return None
 
 

--- a/kenya_compliance_via_slade/patches.txt
+++ b/kenya_compliance_via_slade/patches.txt
@@ -1,5 +1,5 @@
 [pre_model_sync]
 
 [post_model_sync]
-kenya_compliance_via_slade.kenya_compliance_via_slade.patches.create_fields # 05/05/25 
-kenya_compliance_via_slade.kenya_compliance_via_slade.patches.create_connection_links # 05/05/25 
+kenya_compliance_via_slade.kenya_compliance_via_slade.patches.create_fields # 007/05/25 
+kenya_compliance_via_slade.kenya_compliance_via_slade.patches.create_connection_links # 007/05/25 


### PR DESCRIPTION

This pull request introduces targeted improvements across the codebase, addressing functional gaps, enhancing error handling, and removing deprecated files to streamline maintenance.

### 🔧 Functional Enhancements

* **Item Registration Logic:**
  Updated `perform_item_registration` in `apis.py` to prevent registration of disabled items via enhanced validation.
* **Conditional Inventory Submission:**
  Modified `item_registration_on_success` in `remote_response_status_handlers.py` to enqueue inventory submission only if the item maintains stock.
* **Sales Invoice Enhancements:**
  Integrated a `calculate_tax` call during `on_submit` in `server/sales_invoice.py` to ensure tax is calculated at submission time.

### 💰 Tax Feature Improvements

* **Dynamic Tax Label Update:**
  Added `updateTaxAmountLabel` in `client/sales_invoice.js` to reflect company currency in the “Tax Amount” field.
* **Custom Field Enhancement:**
  Updated `custom_tax_amount` in `sales_invoice_item.json` with dynamic label and currency support.

### 🛡️ Improved Error Handling

* **Link Update Resilience:**
  Enhanced `update_links_for_doctypes` in `create_connection_links.py` with `try-except` logic to log errors and avoid runtime halts.
  [\[1\]](diffhunk://#diff-ff6873a1e00c343412fcb64d0c0c2baae17fbad0650c30b4e54c722cd1cc9b44R14) [\[2\]](diffhunk://#diff-ff6873a1e00c343412fcb64d0c0c2baae17fbad0650c30b4e54c722cd1cc9b44R35-R36)
* **Custom Field Generation:**
  Updated `create_fields_from_json.py` to log errors without breaking execution flow during custom field creation.

### 🧹 Code Cleanup

* Removed obsolete patch files (`bom.py`, `customer.py`, etc.) related to custom field creation across various doctypes.
  [\[1\]](diffhunk://#diff-fc7c955e280133634bcb0b4ef0888f8387fb002982a764a61793c4c3694bf5d8L1-L5) [\[2\]](diffhunk://#diff-5e3357767f5e47452d9e230d3e9ca484edbcd0a699e5c9e4116e3804f3fc5231L1-L5) [\[3\]](diffhunk://#diff-f441eb1dca42de934f75546093ca715770142ee1651ae83cd1425e62acebe089L1-L7)

