### PR TITLE
fix: restricts password updates to non-sandbox settings

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/tasks.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/tasks.py
@@ -378,7 +378,7 @@ def send_purchase_information() -> None:
 def update_setting_passwords() -> None:
     settings_list = frappe.get_all(
         "Navari KRA ETIMS Settings",
-        filters={"is_active": 1},
+        filters={"is_active": 1, "sandbox": 0},
         fields=["name"]
     )
     for setting in settings_list:


### PR DESCRIPTION
This pull request includes a small but important change to the `update_setting_passwords` function in `kenya_compliance_via_slade/background_tasks/tasks.py`. The change ensures that only non-sandbox settings are updated by adding a filter for `"sandbox": 0` to the query.