### PR TITLE
fix: round discount amount to four decimal places in invoice payload

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -402,7 +402,7 @@ def build_invoice_payload(
             payload["itemDetails"].append({
                 "product_name": item.item_code,
                 "unit_price": round(base_net_rate + (tax_amount / qty if qty else 0), 4),
-                "discount": item.discount_amount or 0,
+                "discount": round(item.discount_amount, 4) or 0,
                 "quantity": qty,
                 "uom": item.uom or "Pcs",
                 "tax_code": tax_code


### PR DESCRIPTION
This pull request includes a small change to the `build_invoice_payload` function in `kenya_compliance_via_slade/utils.py`. The change ensures that the `discount` field is rounded to 4 decimal places before being used, improving consistency in the payload formatting.