### PR TITLE
fix: round discount amount to four decimal places in invoice payload

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -402,7 +402,7 @@ def build_invoice_payload(
             payload["itemDetails"].append({
                 "product_name": item.item_code,
                 "unit_price": round(base_net_rate + (tax_amount / qty if qty else 0), 4),
-                "discount": item.discount_amount or 0,
+                "discount": round(item.discount_amount, 4) or 0,
                 "quantity": qty,
                 "uom": item.uom or "Pcs",
                 "tax_code": tax_code


### PR DESCRIPTION
This pull request includes a minor update to the `build_invoice_payload` function in `kenya_compliance_via_slade/utils.py`. The change ensures that the `discount` value is rounded to four decimal places before being added to the payload.

* [`kenya_compliance_via_slade/utils.py`](diffhunk://#diff-49f2f650dc9c4dd5f1c270e16a00dad0a48d0ac96ca7a22679b9c93272498ac6L405-R405): Updated the `discount` field in the `itemDetails` dictionary to round `item.discount_amount` to four decimal places for consistency and precision in the invoice payload.