### PR TITLE
fix: enhance sales invoice submission logic by ensuring settings are correctly utilized

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/sales_invoice.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/sales_invoice.py
@@ -14,14 +14,15 @@ def on_submit(doc: Document, method: str = None) -> None:
     )
 
     settings_doc = frappe.get_doc(SETTINGS_DOCTYPE_NAME, {"is_active": 1, "company": company_name})
-
+    
+    calculate_tax(doc)
+    
     if (
         doc.custom_successfully_submitted == 0
         and doc.custom_defer_etims_submission == 0
         and doc.is_opening == "No"
         and settings_doc.sales_auto_submission_enabled
     ):
-        calculate_tax(doc)
         try:
             generic_invoices_on_submit_override(doc, "Sales Invoice")
         except frappe.ValidationError as e:

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/sales_invoice.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/sales_invoice.py
@@ -3,14 +3,23 @@ from frappe.model.document import Document
 
 from .shared_overrides import generic_invoices_on_submit_override
 from ...utils import calculate_tax
+from ...doctype.doctype_names_mapping import SETTINGS_DOCTYPE_NAME
 
 
 def on_submit(doc: Document, method: str = None) -> None:
+    company_name = (
+        doc.company
+        or frappe.defaults.get_user_default("Company")
+        or frappe.get_value("Company", {}, "name")
+    )
+
+    settings_doc = frappe.get_doc(SETTINGS_DOCTYPE_NAME, {"is_active": 1, "company": company_name})
 
     if (
         doc.custom_successfully_submitted == 0
         and doc.custom_defer_etims_submission == 0
         and doc.is_opening == "No"
+        and settings_doc.sales_auto_submission_enabled
     ):
         calculate_tax(doc)
         try:

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/shared_overrides.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/shared_overrides.py
@@ -30,8 +30,8 @@ def generic_invoices_on_submit_override(
         or frappe.get_value("Company", {}, "name")
     )
 
-    settings_doc = frappe.get_doc(SETTINGS_DOCTYPE_NAME, {"is_active": 1, "company": company_name})
-    if doc.prevent_etims_submission or not settings_doc.sales_auto_submission_enabled or (hasattr(doc, "etr_invoice_number") and doc.etr_invoice_number):
+    # settings_doc = frappe.get_doc(SETTINGS_DOCTYPE_NAME, {"is_active": 1, "company": company_name})
+    if doc.prevent_etims_submission or (hasattr(doc, "etr_invoice_number") and doc.etr_invoice_number):
         return
 
 


### PR DESCRIPTION
This pull request refactors the handling of settings and tax calculation in the sales invoice submission process. The primary changes involve moving the retrieval of the settings document to the `on_submit` function and simplifying the `generic_invoices_on_submit_override` function.

### Refactoring of settings handling:

* [`kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/sales_invoice.py`](diffhunk://#diff-3cffe9e9d8e012429e2716ac6b2b6dcc3464e7a1f2818c3b86a9966137f97b43R6-L15): Added logic to retrieve the settings document (`settings_doc`) in the `on_submit` function, ensuring it is only fetched once and used to check `sales_auto_submission_enabled`. This improves code clarity and reduces redundancy.

* [`kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/shared_overrides.py`](diffhunk://#diff-801b286fb34795738721b20523c4307aaf8713fd3dcbf13aaa81bb52e30fb08fL33-R34): Removed the redundant retrieval of the settings document in the `generic_invoices_on_submit_override` function, as this is now handled in `on_submit`. This simplifies the function and avoids unnecessary database calls.