### PR TITLE
fix(auth): reset password on JSON decode failure and improve error context

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/api_builder.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/api_builder.py
@@ -11,7 +11,7 @@ from frappe.integrations.utils import create_request_log
 from frappe.model.document import Document
 
 from ..logger import etims_logger
-from ..utils import update_last_request_date, update_navari_settings_with_token
+from ..utils import update_last_request_date, update_navari_settings_with_token, reset_auth_password
 from .remote_response_status_handlers import on_slade_error
 
 
@@ -286,6 +286,9 @@ class EndpointsBuilder(BaseEndpointsBuilder):
                     error = response_data[0]
                 else:
                     error = str(response_data)
+                    
+                if "could not decode json: Expecting value: line 1 column 1 (char 0)" in error:
+                    reset_auth_password(self._settings.name)
                     
                 update_integration_request(
                     self.integration_request.name,

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/handlers.py
@@ -33,7 +33,12 @@ def handle_slade_errors(
 
     try:
         # Log the error with more context in the error message
-        frappe.log_error(message=log_message, title="Slade Error")
+        frappe.log_error(
+            message=log_message, 
+            title="Slade Error", 
+            reference_doctype=doctype,
+            reference_name=document_name
+        )
     except Exception as e:
         # If logging fails, fall back to standard error logging
         etims_logger.error(f"Error while logging Slade error: {str(e)}")

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/custom_fields/sales_invoice.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/custom_fields/sales_invoice.json
@@ -32,7 +32,6 @@
   },
   {
     "allow_on_submit": 1,
-    "default": "Cash",
     "fieldname": "custom_payment_type",
     "fieldtype": "Link",
     "insert_after": "custom_payment_and_transaction_details",


### PR DESCRIPTION

This pull request introduces enhancements to error handling and logging mechanisms, adds functionality to reset authentication passwords in specific scenarios, and modifies a default value for a custom field. These changes aim to improve system robustness and user experience.

### Error handling and logging improvements:
* [`kenya_compliance_via_slade/kenya_compliance_via_slade/handlers.py`](diffhunk://#diff-1908942423b407f5d0239e6e234d48296180db8e67071c3c274f6b1047d017c2L36-R41): Enhanced the `frappe.log_error` call in `handle_slade_errors` to include `reference_doctype` and `reference_name`, providing more context for error tracking.

### Authentication password reset:
* [`kenya_compliance_via_slade/kenya_compliance_via_slade/apis/api_builder.py`](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R290-R292): Added the `reset_auth_password` utility to handle specific JSON decoding errors in `make_remote_call`, ensuring the system can recover from authentication issues.
* [`kenya_compliance_via_slade/kenya_compliance_via_slade/apis/api_builder.py`](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5L14-R14): Imported the `reset_auth_password` function to make it available for use in the API builder module.

### Custom field modification:
* [`kenya_compliance_via_slade/kenya_compliance_via_slade/patches/custom_fields/sales_invoice.json`](diffhunk://#diff-0f558207bf49e2a0525e76732a2fe78fda567c94c888aeb8b06515107ef529cfL35): Removed the default value `"Cash"` from the `custom_payment_type` field, allowing for more flexibility in payment type selection.