### PR TITLE
Fix: correct activeSetting validation and enforce submission restriction on Sales Invoice

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/bom.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/bom.js
@@ -12,7 +12,7 @@ frappe.ui.form.on(doctype, {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       let itemCode;
 
       frappe.db.get_value("Item", { name: frm.doc.item }, ["*"], (response) => {

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/branch.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/branch.js
@@ -12,7 +12,7 @@ frappe.ui.form.on(doctype, {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       frm.add_custom_button(
         __("Get Imported Items"),
         function () {

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/branch_list.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/branch_list.js
@@ -12,7 +12,7 @@ frappe.listview_settings[doctypeName] = {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       listview.page.add_inner_button(__("Get Branches"), function (listview) {
         frappe.call({
           method:

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/customer.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/customer.js
@@ -13,7 +13,7 @@ frappe.ui.form.on(doctype, {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       frappe.call({
         method: "frappe.client.get_value",
         args: {

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/customer_list.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/customer_list.js
@@ -12,7 +12,7 @@ frappe.listview_settings[doctypeName] = {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       listview.page.add_inner_button(
         __("Get Customers"),
         function (listview) {

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/item_price.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/item_price.js
@@ -15,7 +15,7 @@ frappe.ui.form.on(doctypeName, {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       if (!frm.is_new()) {
         const submit_name = !frm.doc.custom_slade_id
           ? "Submit Item Price"

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/item_price_list.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/item_price_list.js
@@ -12,7 +12,7 @@ frappe.listview_settings[doctypeName] = {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       listview.page.add_inner_button(
         __("Fetch eTims Item Prices"),
         function (listview) {

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items.js
@@ -11,7 +11,7 @@ frappe.ui.form.on(itemDoctypName, {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       if (frm.doc.custom_item_registered) {
         frm.toggle_enable("custom_item_classification", false);
         frm.toggle_enable("custom_etims_country_of_origin", false);

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items_list.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items_list.js
@@ -10,7 +10,7 @@ frappe.listview_settings[doctypeName].onload = async function (listview) {
       doctype: settingsDoctypeName,
     },
   });
-  if (activeSetting?.name) {
+  if (activeSetting?.message?.name) {
     listview.page.add_inner_button(
       __("Get Imported Items"),
       function (listview) {

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/mode_of_payment.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/mode_of_payment.js
@@ -11,7 +11,7 @@ frappe.ui.form.on(doctypeName, {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       if (!frm.doc.custom_submitted_successfully) {
         frm.add_custom_button(
           __("Submit to eTims"),

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/mode_of_payment_list.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/mode_of_payment_list.js
@@ -11,7 +11,7 @@ frappe.listview_settings[doctypeName] = {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       listview.page.add_inner_button(
         __("Submit all to eTims"),
         function () {

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/pos_invoice.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/pos_invoice.js
@@ -15,7 +15,7 @@ frappe.ui.form.on(doctypeName, {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       frappe.db.get_value(
         settingsDoctypeName,
         {

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/pos_invoice_list.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/pos_invoice_list.js
@@ -9,7 +9,7 @@ frappe.listview_settings[doctypeName].onload = async function (listview) {
       doctype: settingsDoctypeName,
     },
   });
-  if (activeSetting?.name) {
+  if (activeSetting?.message?.name) {
     listview.page.add_action_item(__("Bulk Submit to eTims"), function () {
       bulkSubmitInvoices(listview, doctypeName);
     });

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/price_list.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/price_list.js
@@ -15,7 +15,7 @@ frappe.ui.form.on(doctypeName, {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       frm.set_query("custom_warehouse", function () {
         return {
           filters: {

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/price_list_list.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/price_list_list.js
@@ -12,7 +12,7 @@ frappe.listview_settings[doctypeName] = {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       listview.page.add_inner_button(
         __("Fetch eTims Price List List"),
         function (listview) {

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/purchase_invoice.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/purchase_invoice.js
@@ -11,7 +11,7 @@ frappe.ui.form.on(parentDoctype, {
       },
     });
 
-    if (activeSetting?.name && frm.doc.docstatus !== 0) {
+    if (activeSetting?.message?.name && frm.doc.docstatus !== 0) {
       if (!frm.doc.custom_submitted_successfully) {
         frm.add_custom_button(
           __("Send Invoice"),

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
@@ -24,7 +24,7 @@ frappe.ui.form.on(parentDoctype, {
     });
 
     if (
-      activeSetting?.name &&
+      activeSetting?.message?.name &&
       frm.doc.docstatus !== 0 &&
       !frm.doc.prevent_etims_submission
     ) {

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice_list.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice_list.js
@@ -10,7 +10,7 @@ frappe.listview_settings[doctypeName].onload = async function (listview) {
     },
   });
 
-  if (activeSetting?.name) {
+  if (activeSetting?.message?.name) {
     listview.page.add_action_item(__("Bulk Submit to eTims"), function () {
       bulkSubmitInvoices(listview, doctypeName);
     });

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/stock_ledger_entry.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/stock_ledger_entry.js
@@ -14,7 +14,7 @@ frappe.ui.form.on(doctypeName, {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       if (!frm.is_new()) {
         if (!frm.doc.custom_slade_id) {
           frm.add_custom_button(

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/supplier.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/supplier.js
@@ -12,7 +12,7 @@ frappe.ui.form.on(doctype, {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       if (!frm.is_new() && frm.doc.tax_id) {
         frm.add_custom_button(
           __("Perform Supplier Search"),

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/supplier_list.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/supplier_list.js
@@ -12,7 +12,7 @@ frappe.listview_settings[doctypeName] = {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       listview.page.add_inner_button(
         __("Submit all Suppliers to eTims"),
         function () {

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/uom.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/uom.js
@@ -15,7 +15,7 @@ frappe.ui.form.on(doctypeName, {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       if (!frm.is_new()) {
         const submit_name = !frm.doc.custom_slade_id
           ? "Submit UOM Details"

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/uom_list.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/uom_list.js
@@ -13,7 +13,7 @@ frappe.listview_settings[doctypeName] = {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       listview.page.add_inner_button(
         __("Fetch eTims UOM List"),
         function (listview) {

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/warehouse.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/warehouse.js
@@ -15,7 +15,7 @@ frappe.ui.form.on(doctypeName, {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       if (!frm.is_new()) {
         const submit_name = !frm.doc.custom_slade_id
           ? "Submit Warehouse"

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/warehouse_list.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/warehouse_list.js
@@ -12,7 +12,7 @@ frappe.listview_settings[doctypeName] = {
       },
     });
 
-    if (activeSetting?.name) {
+    if (activeSetting?.message?.name) {
       listview.page.add_inner_button(
         __("Fetch eTims Warehouse List"),
         function (listview) {

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/custom_fields/sales_invoice.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/custom_fields/sales_invoice.json
@@ -52,7 +52,7 @@
     "insert_after": "custom_column_break_arjmp",
     "label": "Prevent Submitting to eTims",
     "name": "Sales Invoice-prevent_etims_submission",
-    "allow_on_submit": 1,
+    "allow_on_submit": 0,
     "default": "0"
   },
   {


### PR DESCRIPTION
**This pull request includes two fixes to improve eTims integration and validation consistency in the `kenya_compliance_via_slade` module.**

### ✅ Fix: Standardize `activeSetting` Checks

Fixes an error where `activeSetting?.name` was used instead of the correct `activeSetting?.message?.name`. This update ensures consistency with the expected structure returned by `get_active_setting`.

---

### 🛠️ Fix: Prevent Sales Invoice Submission to eTims

Disables the `allow_on_submit` property for the "Prevent Submitting to eTims" custom field in Sales Invoices. This ensures that when the flag is active, documents cannot be submitted to eTims, enforcing the intended behavior.
