### PR TITLE
fix:restrict settings retrieval to mapped companies only

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/purchase_invoice.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/purchase_invoice.py
@@ -41,29 +41,30 @@ def on_submit(doc: Document, method: str = None) -> None:
 def submit_purchase_invoice(doc: Document) -> None:
     if doc.is_return == 0:
         # TODO: Handle cases when item tax templates have not been picked
-
         company_name = (
             doc.company
-            or frappe.defaults.get_user_default("Company")
-            or frappe.get_value("Company", {}, "name")
+            # or frappe.defaults.get_user_default("Company")
+            # or frappe.get_value("Company", {}, "name")
         )
-
         settings_doc = get_settings(company_name=company_name)
 
-        company_name = (
-            doc.company
-            or frappe.defaults.get_user_default("Company")
-            or frappe.get_value("Company", {}, "name")
-        )
-        payload = build_purchase_invoice_payload(doc, company_name)
-        process_request(
-            payload,
-            "TrnsPurchaseSaveReq",
-            purchase_invoice_submission_on_success,
-            request_method="POST",
-            doctype="Purchase Invoice",
-            settings_name=settings_doc.name,
-        )
+        # company_name = (
+        #     doc.company
+        #     # or frappe.defaults.get_user_default("Company")
+        #     # or frappe.get_value("Company", {}, "name")
+        # )
+        
+        if settings_doc:
+            payload = build_purchase_invoice_payload(doc, company_name)
+            process_request(
+                payload,
+                "TrnsPurchaseSaveReq",
+                purchase_invoice_submission_on_success,
+                request_method="POST",
+                doctype="Purchase Invoice",
+                settings_name=settings_doc.name,
+            )
+  
 
 
 @frappe.whitelist()

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -312,9 +312,10 @@ def get_settings(company_name: str = None, branch_id: str = None, settings_name:
         
     company_name = (
         company_name
-        or frappe.defaults.get_user_default("Company")
-        or frappe.get_value("Company", {}, "name")
+        # or frappe.defaults.get_user_default("Company")
+        # or frappe.get_value("Company", {}, "name")
     )
+   
     if frappe.db.exists(
         ORGANISATION_MAPPING_DOCTYPE_NAME, 
         {"company": company_name, "is_active": 1}
@@ -325,17 +326,19 @@ def get_settings(company_name: str = None, branch_id: str = None, settings_name:
             "parent",
             as_dict=True,
         )
+        
+        
         if mapping and mapping.parent:
             return frappe.get_doc(SETTINGS_DOCTYPE_NAME, mapping.parent).as_dict()
     
-    if frappe.db.exists(SETTINGS_DOCTYPE_NAME, {"is_active": 1}):
-        settings = frappe.db.get_value(
-            SETTINGS_DOCTYPE_NAME,
-            {"is_active": 1},
-            "*",
-            as_dict=True,
-        )
-        return settings
+    # if frappe.db.exists(SETTINGS_DOCTYPE_NAME, {"is_active": 1}):
+    #     settings = frappe.db.get_value(
+    #         SETTINGS_DOCTYPE_NAME,
+    #         {"is_active": 1},
+    #         "*",
+    #         as_dict=True,
+    #     )
+    #     return settings
     
     return None
 


### PR DESCRIPTION
### fix: enforce strict company-to-settings mapping

- Removed fallback logic that previously returned the first active settings (`is_active=1`) if no organisation mapping was found.
- Now, settings are only returned if explicitly linked via `ORGANISATION_MAPPING_DOCTYPE_NAME`.
- Also removed default global company fallback logic (`frappe.defaults.get_user_default("Company")`, etc.) — now the system strictly uses the `company` provided on the document (e.g., Invoice).
- This ensures stricter company-to-settings validation and prevents unintended settings usage or misconfiguration.

<img width="2052" height="1584" alt="image (12)" src="https://github.com/user-attachments/assets/cd0e72a8-ff1f-45fe-87cf-84a67f98d553" />

