### PR TITLE
fix(client): skip eTims actions for new forms in refresh events

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/branch.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/branch.js
@@ -4,6 +4,7 @@ const settingsDoctypeName = "Navari KRA eTims Settings";
 frappe.ui.form.on(doctype, {
   refresh: async function (frm) {
     const companyName = frappe.boot.sysdefaults.company;
+    if (frm.is_new()) return;
     const { message: activeSetting } = await frappe.call({
       method:
         "kenya_compliance_via_slade.kenya_compliance_via_slade.utils.get_active_settings",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/customer.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/customer.js
@@ -4,6 +4,8 @@ frappe.ui.form.on(doctype, {
   refresh: async function (frm) {
     let currency = frm.doc.default_currency || "KES";
 
+    if (frm.is_new()) return;
+
     const { message: data } = await frappe.call({
       method:
         "kenya_compliance_via_slade.kenya_compliance_via_slade.utils.get_etims_action_data",
@@ -17,7 +19,7 @@ frappe.ui.form.on(doctype, {
     const registeredMappings = data?.registered_mappings || [];
     const unregisteredSettings = data?.unregistered_settings || [];
 
-    if (!allSettings.length || frm.is_new()) return;
+    if (!allSettings.length) return;
 
     frappe.call({
       method: "frappe.client.get_value",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/item_price.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/item_price.js
@@ -7,6 +7,7 @@ const settingsDoctypeName = "Navari KRA eTims Settings";
 frappe.ui.form.on(doctypeName, {
   refresh: async function (frm) {
     const companyName = frappe.boot.sysdefaults.company;
+    if (frm.is_new()) return;
     const { message: activeSetting } = await frappe.call({
       method:
         "kenya_compliance_via_slade.kenya_compliance_via_slade.utils.get_active_settings",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items.js
@@ -2,6 +2,7 @@ const itemDoctypName = "Item";
 
 frappe.ui.form.on(itemDoctypName, {
   refresh: async function (frm) {
+    if (frm.is_new()) return;
     const { message: data } = await frappe.call({
       method:
         "kenya_compliance_via_slade.kenya_compliance_via_slade.utils.get_etims_action_data",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/mode_of_payment.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/mode_of_payment.js
@@ -3,6 +3,7 @@ const settingsDoctypeName = "Navari KRA eTims Settings";
 
 frappe.ui.form.on(doctypeName, {
   refresh: async function (frm) {
+    if (frm.is_new()) return;
     const { message: activeSetting } = await frappe.call({
       method:
         "kenya_compliance_via_slade.kenya_compliance_via_slade.utils.get_active_settings",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/price_list.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/price_list.js
@@ -7,6 +7,7 @@ const settingsDoctypeName = "Navari KRA eTims Settings";
 frappe.ui.form.on(doctypeName, {
   refresh: async function (frm) {
     const companyName = frappe.boot.sysdefaults.company;
+    if (frm.is_new()) return;
     const { message: activeSetting } = await frappe.call({
       method:
         "kenya_compliance_via_slade.kenya_compliance_via_slade.utils.get_active_settings",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
@@ -15,12 +15,11 @@ frappe.realtime.on("refresh_form", function (name) {
 frappe.ui.form.on(parentDoctype, {
   refresh: async function (frm) {
     await updateTaxAmountLabel(frm);
+    if (frm.is_new()) return;
     const { message: activeSetting } = await frappe.call({
       method:
         "kenya_compliance_via_slade.kenya_compliance_via_slade.utils.get_active_settings",
-      args: { doctype: settingsDoctypeName,
-        company: frm.doc.company
-       },
+      args: { doctype: settingsDoctypeName, company: frm.doc.company },
     });
 
     if (

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/stock_ledger_entry.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/stock_ledger_entry.js
@@ -6,6 +6,7 @@ const settingsDoctypeName = "Navari KRA eTims Settings";
 
 frappe.ui.form.on(doctypeName, {
   refresh: async function (frm) {
+    if (frm.is_new()) return;
     const { message: activeSetting } = await frappe.call({
       method:
         "kenya_compliance_via_slade.kenya_compliance_via_slade.utils.get_active_settings",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/supplier.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/supplier.js
@@ -3,6 +3,7 @@ const settingsDoctypeName = "Navari KRA eTims Settings";
 
 frappe.ui.form.on(doctype, {
   refresh: async function (frm) {
+    if (frm.is_new()) return;
     const { message: data } = await frappe.call({
       method:
         "kenya_compliance_via_slade.kenya_compliance_via_slade.utils.get_etims_action_data",
@@ -16,7 +17,7 @@ frappe.ui.form.on(doctype, {
     const registeredMappings = data?.registered_mappings || [];
     const unregisteredSettings = data?.unregistered_settings || [];
 
-    if (!allSettings.length || frm.is_new()) return;
+    if (!allSettings.length) return;
 
     // Add action buttons based on registration status
     addSupplierActionButtons(frm, {

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/uom.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/uom.js
@@ -7,6 +7,7 @@ const settingsDoctypeName = "Navari KRA eTims Settings";
 frappe.ui.form.on(doctypeName, {
   refresh: async function (frm) {
     const companyName = frappe.boot.sysdefaults.company;
+    if (frm.is_new()) return;
     const { message: activeSetting } = await frappe.call({
       method:
         "kenya_compliance_via_slade.kenya_compliance_via_slade.utils.get_active_settings",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/warehouse.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/warehouse.js
@@ -7,6 +7,7 @@ const settingsDoctypeName = "Navari KRA eTims Settings";
 frappe.ui.form.on(doctypeName, {
   refresh: async function (frm) {
     const companyName = frappe.boot.sysdefaults.company;
+    if (frm.is_new()) return;
     const { message: activeSetting } = await frappe.call({
       method:
         "kenya_compliance_via_slade.kenya_compliance_via_slade.utils.get_active_settings",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -1286,8 +1286,13 @@ def get_etims_action_data(doctype: str, docname: str = None) -> dict[str, Any]:
         }
     try:
         doc = frappe.get_doc(doctype, docname)
-    except frappe.DoesNotExistError:
-        frappe.throw(f"{doctype} '{docname}' does not exist.")
+    except :
+        return {
+            "settings": active_settings,
+            "has_mappings": False,
+            "registered_mappings": [],
+            "unregistered_settings": []
+        }
 
 
     if not active_settings:


### PR DESCRIPTION
This pull request improves the robustness and efficiency of client-side form scripts and backend error handling for the Kenya Compliance app. The main changes ensure that certain API calls and logic are only executed for existing documents (not new/unsaved ones), and backend errors when fetching documents are handled gracefully.

Key changes:

**Client-side form logic improvements:**

* Added checks in multiple client-side `refresh` handlers (e.g., `customer.js`, `supplier.js`, `items.js`, `item_price.js`, `mode_of_payment.js`, `price_list.js`, `sales_invoice.js`, `stock_ledger_entry.js`, `uom.js`, `warehouse.js`, `branch.js`) to return early if the form is new (`frm.is_new()`), preventing unnecessary API calls and logic execution for unsaved documents. [[1]](diffhunk://#diff-71cfee93e72e7c20998ac3ad4d463ff8c719a07f9f753084a3a33193847ac996R7-R8) [[2]](diffhunk://#diff-71cfee93e72e7c20998ac3ad4d463ff8c719a07f9f753084a3a33193847ac996L20-R22) [[3]](diffhunk://#diff-29f941483fa727ccc00e91075ca8d6889086ac83aa4bc1b5b09b7af24586bea4R6) [[4]](diffhunk://#diff-29f941483fa727ccc00e91075ca8d6889086ac83aa4bc1b5b09b7af24586bea4L19-R20) [[5]](diffhunk://#diff-fc8afe95c2310f3d438f3a77f2f4a8f5224eab5d88950f26c3736f77953dcee1R5) [[6]](diffhunk://#diff-f95582b01cff2b8be0fb2df6d24aa9b324d7afb7d6b6228354ae51117f3b834aR10) [[7]](diffhunk://#diff-9d34ca1421aa2984fae6c96a017280248bb43ceee41b4224784a3d682bce40faR6) [[8]](diffhunk://#diff-3d9867485cc99c6b268a2967ac70dff6996b745721ebf37c2fe4c0c611028c10R10) [[9]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8R18-R22) [[10]](diffhunk://#diff-0a35ec49127013977f4edb28177987b21fb05a8fe88f6872c844528b19cafbd8R9) [[11]](diffhunk://#diff-94ed53a2dd4e2db21bac20a5c4890bbef57707a542d591d347aaf378c370a9bcR10) [[12]](diffhunk://#diff-14878a171e36ec5d685d1f1b7c14aee8fd865f70c5fa09c69939c3c5f1c8d7cdR10) [[13]](diffhunk://#diff-f431f2fe40be142ffc61ec620a279747b9dd4e695f7699f89bf8833e762c83c3R7)

**Backend error handling:**

* Updated `get_etims_action_data` in `utils.py` to handle all exceptions when fetching a document. Instead of throwing an error, it now returns a default response with empty mappings and settings, improving resilience to missing or invalid documents.