### PR TITLE
fix(workstations): remove unused department mapping from update process

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/task_response_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/task_response_handlers.py
@@ -412,12 +412,6 @@ def update_workstations(response: dict, settings_name: str, **kwargs) -> None:
         "workstation_type_display": "workstation_type_display",
         "workstation_type": "workstation_type",
         "is_billing_point": lambda x: 1 if x.get("is_billing_point") else 0,
-        "department": {
-            "doctype": "Department",
-            "link_field": "org_unit",
-            "filter_field": "custom_slade_id",
-            "extract_field": "name",
-        },
     }
     update_documents(
         response, WORKSTATION_DOCTYPE_NAME, field_mapping, filter_field="slade_id", settings_name=settings_name


### PR DESCRIPTION
This pull request makes a small change to the workstation update logic in `task_response_handlers.py` by removing the mapping for the `department` field. This simplifies the field mapping used when updating workstation documents.