### PR TITLE
fix(invoice): improve payload with Slade360 IDs, invoice date, and consistent parameter handling

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
@@ -495,11 +495,11 @@ def verify_and_fix_invoice_info(response: dict, document_name: str, doctype: str
             process_sales_sign(document_name, doctype, doc.custom_slade_id)
         return
     
-    revision_count = int(doc.get("revision_count") or 0)
+    revision_count = int(doc.get("revision_count") or 0) 
     if revision_count > 0:
         verify_and_fix_invoice_revisions(doctype, document_name, data, settings_name)
 
-    invoice_data = build_return_invoice_payload(doc, data) if doc.is_return else build_invoice_payload(doc)
+    invoice_data = build_return_invoice_payload(doc, data) if doc.is_return else build_invoice_payload(doc, settings_name)
     
     if is_invoice_data_matching(invoice_data, data):
         process_invoice_response(response, document_name, doctype)

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/shared_overrides.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/shared_overrides.py
@@ -76,7 +76,7 @@ def generic_invoices_on_submit_override(
         )
         
     else:
-        payload = build_invoice_payload(doc)
+        payload = build_invoice_payload(doc, settings_doc.name)
         additional_context = {
             "invoice_type": invoice_type,
         }

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -360,15 +360,24 @@ def extract_document_series_number(document: Document) -> int | None:
 
 
 def build_invoice_payload(
-    invoice: Document
+    invoice: Document,
+    settings_name: str
 ) -> dict:
     reference_number = get_invoice_reference_number(invoice)
+    dt_obj = datetime.fromisoformat(f"{invoice.posting_date} {invoice.posting_time or '00:00:00'}")
+    formatted_date = dt_obj.strftime("%Y-%m-%dT%H:%M:%SZ")
     payload = {
         "document_name": invoice.name,
         "reference_number": reference_number,
         "sales_type": "credit",
         "customer_pin": frappe.get_value("Customer", invoice.customer, "tax_id") or None,
         "partner_name": frappe.get_value("Customer", invoice.customer, "customer_name") or None,
+        "invoice_date": formatted_date,
+        "customer_id": get_slade360_id(
+            "Customer",
+            invoice.customer,
+            settings_name,
+        ),
         "itemDetails": []
     }
     
@@ -384,7 +393,12 @@ def build_invoice_payload(
             "unit_price": round(base_net_rate + (tax_amount / qty if qty else 0), 4),
             "quantity": qty,
             "uom": item.uom or "Pcs",
-            "tax_code": tax_code
+            "tax_code": tax_code,
+            "product_id": get_slade360_id(
+                "Item",
+                item.item_code,
+                settings_name,
+            ),
         })
 
     return payload


### PR DESCRIPTION
This pull request fixes issues in invoice submission by enhancing payload construction, ensuring proper synchronization with Slade360, and standardizing function usage across the codebase.

### Invoice Payload Construction

* `build_invoice_payload` now requires a `settings_name` parameter to fetch identifiers consistently.
* Added new fields to the payload:

  * `invoice_date` (ISO 8601 formatted)
  * `customer_id` (via `get_slade360_id`)
  * `product_id` (for each item, via `get_slade360_id`)
* Ensures both Slade360 IDs and corresponding names are included in the invoice payload.

### Consistency & Refactoring

* Updated invoice verification handler and generic submission override to pass `settings_name`, ensuring consistent payload building across the system.
* Improved reliability of document tracking and synchronization with Slade360 by aligning payload data requirements.

These changes resolve submission issues and improve data integrity when syncing invoices to Slade360.

