### PR TITLE
fix(invoice): improve payload with Slade360 IDs, invoice date, and consistent parameter handling

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
@@ -495,11 +495,11 @@ def verify_and_fix_invoice_info(response: dict, document_name: str, doctype: str
             process_sales_sign(document_name, doctype, doc.custom_slade_id)
         return
     
-    revision_count = int(doc.get("revision_count") or 0)
+    revision_count = int(doc.get("revision_count") or 0) 
     if revision_count > 0:
         verify_and_fix_invoice_revisions(doctype, document_name, data, settings_name)
 
-    invoice_data = build_return_invoice_payload(doc, data) if doc.is_return else build_invoice_payload(doc)
+    invoice_data = build_return_invoice_payload(doc, data) if doc.is_return else build_invoice_payload(doc, settings_name)
     
     if is_invoice_data_matching(invoice_data, data):
         process_invoice_response(response, document_name, doctype)

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/shared_overrides.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/shared_overrides.py
@@ -76,7 +76,7 @@ def generic_invoices_on_submit_override(
         )
         
     else:
-        payload = build_invoice_payload(doc)
+        payload = build_invoice_payload(doc, settings_doc.name)
         additional_context = {
             "invoice_type": invoice_type,
         }

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -360,15 +360,24 @@ def extract_document_series_number(document: Document) -> int | None:
 
 
 def build_invoice_payload(
-    invoice: Document
+    invoice: Document,
+    settings_name: str
 ) -> dict:
     reference_number = get_invoice_reference_number(invoice)
+    dt_obj = datetime.fromisoformat(f"{invoice.posting_date} {invoice.posting_time or '00:00:00'}")
+    formatted_date = dt_obj.strftime("%Y-%m-%dT%H:%M:%SZ")
     payload = {
         "document_name": invoice.name,
         "reference_number": reference_number,
         "sales_type": "credit",
         "customer_pin": frappe.get_value("Customer", invoice.customer, "tax_id") or None,
         "partner_name": frappe.get_value("Customer", invoice.customer, "customer_name") or None,
+        "invoice_date": formatted_date,
+        "customer_id": get_slade360_id(
+            "Customer",
+            invoice.customer,
+            settings_name,
+        ),
         "itemDetails": []
     }
     
@@ -384,7 +393,12 @@ def build_invoice_payload(
             "unit_price": round(base_net_rate + (tax_amount / qty if qty else 0), 4),
             "quantity": qty,
             "uom": item.uom or "Pcs",
-            "tax_code": tax_code
+            "tax_code": tax_code,
+            "product_id": get_slade360_id(
+                "Item",
+                item.item_code,
+                settings_name,
+            ),
         })
 
     return payload


### PR DESCRIPTION
This pull request updates the invoice payload construction logic to ensure that additional fields are included and that the correct settings are used when building invoice payloads. The changes affect both utility functions and override handlers, improving consistency and correctness in how invoice data is generated and processed.

**Invoice payload construction improvements:**

* Updated the `build_invoice_payload` function to accept an additional `settings_name` parameter, allowing it to fetch context-specific data such as customer and product IDs.
* Added new fields to the invoice payload: `invoice_date` (properly formatted using posting date and time), `customer_id` (using `get_slade360_id`), and `product_id` for each item in `itemDetails`. [[1]](diffhunk://#diff-49f2f650dc9c4dd5f1c270e16a00dad0a48d0ac96ca7a22679b9c93272498ac6L363-R380) [[2]](diffhunk://#diff-49f2f650dc9c4dd5f1c270e16a00dad0a48d0ac96ca7a22679b9c93272498ac6L387-R401)

**Integration and usage updates:**

* Modified calls to `build_invoice_payload` in `verify_and_fix_invoice_info` and `generic_invoices_on_submit_override` to pass the `settings_name` or `settings_doc.name` argument, ensuring the payload includes the correct context. [[1]](diffhunk://#diff-07fa816e70125704befdf104e9a2dc83383e393842f04b759ae1ad8ea85f4633L502-R502) [[2]](diffhunk://#diff-801b286fb34795738721b20523c4307aaf8713fd3dcbf13aaa81bb52e30fb08fL79-R79)