### PR TITLE
fix(credit-note): update payload to use 'product' and 'new_price' fields

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -1635,14 +1635,14 @@ def prepare_credit_note_items_payload(
     credit_note_items = []
     for item in items:
         credit_note_items.append({
-            "item_name": get_slade360_id(
+            "product": get_slade360_id(
                 "Item",
                 item.get("product_name"),
                 settings_name,
             ),
             "credit_note": credit_note,
             "quantity": abs(item.get("quantity", 0)),
-            "source_organisation_unit": data.get("source_organisation_unit"),
+            "new_price": round(abs(item.get("price_inclusive_tax", 0)), 4),
             "organisation": data.get("organisation"),
         })
     return credit_note_items


### PR DESCRIPTION
This pull request updates the payload structure for credit note items in the `prepare_credit_note_items_payload` function to better align with the expected data model. The changes focus on renaming fields and ensuring the payload contains the correct attributes.

Payload structure updates:

* Renamed the `item_name` field to `product` and ensured it uses the Slade360 ID for the product name.
* Replaced `source_organisation_unit` with `new_price`, which is now calculated as the rounded absolute value of `price_inclusive_tax`.