### PR TITLE
fix:restrict settings retrieval to mapped companies only

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -312,9 +312,10 @@ def get_settings(company_name: str = None, branch_id: str = None, settings_name:
         
     company_name = (
         company_name
-        or frappe.defaults.get_user_default("Company")
-        or frappe.get_value("Company", {}, "name")
+        # or frappe.defaults.get_user_default("Company")
+        # or frappe.get_value("Company", {}, "name")
     )
+    
     if frappe.db.exists(
         ORGANISATION_MAPPING_DOCTYPE_NAME, 
         {"company": company_name, "is_active": 1}
@@ -328,16 +329,18 @@ def get_settings(company_name: str = None, branch_id: str = None, settings_name:
         if mapping and mapping.parent:
             return frappe.get_doc(SETTINGS_DOCTYPE_NAME, mapping.parent).as_dict()
     
-    if frappe.db.exists(SETTINGS_DOCTYPE_NAME, {"is_active": 1}):
-        settings = frappe.db.get_value(
-            SETTINGS_DOCTYPE_NAME,
-            {"is_active": 1},
-            "*",
-            as_dict=True,
-        )
-        return settings
+    # if frappe.db.exists(SETTINGS_DOCTYPE_NAME, {"is_active": 1}):
+    #     settings = frappe.db.get_value(
+    #         SETTINGS_DOCTYPE_NAME,
+    #         {"is_active": 1},
+    #         "*",
+    #         as_dict=True,
+    #     )
+    #     frappe.throw(str(settings))
+    #     return settings
     
     return None
+
 
 
 def get_branch_id(company_name: str, vendor: str) -> str | None:

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -1236,12 +1236,12 @@ def get_active_settings(doctype: str = SETTINGS_DOCTYPE_NAME, company: str = Non
             if mapped_settings:
                 return mapped_settings
         
-        return frappe.get_all(
-            doctype,
-            filters={"is_active": 1},
-            fields=["name", "company"],
-            ignore_permissions=True
-        ) or []
+        # return frappe.get_all(
+        #     doctype,
+        #     filters={"is_active": 1},
+        #     fields=["name", "company"],
+        #     ignore_permissions=True
+        # ) or []
 
     except Exception:
         frappe.log_error(frappe.get_traceback(), _("Failed to get active settings"))


### PR DESCRIPTION
Just a repeat of PR I had made before reference #116 

It was overidden or so.

Also fix: Only show etims action button when company has been registered on etims settings referencing #117 