### PR TITLE
Refactor Settings Retrieval: Remove Fallback Logic for Default Company and Active Settings

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -312,9 +312,10 @@ def get_settings(company_name: str = None, branch_id: str = None, settings_name:
         
     company_name = (
         company_name
-        or frappe.defaults.get_user_default("Company")
-        or frappe.get_value("Company", {}, "name")
+        # or frappe.defaults.get_user_default("Company")
+        # or frappe.get_value("Company", {}, "name")
     )
+    
     if frappe.db.exists(
         ORGANISATION_MAPPING_DOCTYPE_NAME, 
         {"company": company_name, "is_active": 1}
@@ -328,16 +329,18 @@ def get_settings(company_name: str = None, branch_id: str = None, settings_name:
         if mapping and mapping.parent:
             return frappe.get_doc(SETTINGS_DOCTYPE_NAME, mapping.parent).as_dict()
     
-    if frappe.db.exists(SETTINGS_DOCTYPE_NAME, {"is_active": 1}):
-        settings = frappe.db.get_value(
-            SETTINGS_DOCTYPE_NAME,
-            {"is_active": 1},
-            "*",
-            as_dict=True,
-        )
-        return settings
+    # if frappe.db.exists(SETTINGS_DOCTYPE_NAME, {"is_active": 1}):
+    #     settings = frappe.db.get_value(
+    #         SETTINGS_DOCTYPE_NAME,
+    #         {"is_active": 1},
+    #         "*",
+    #         as_dict=True,
+    #     )
+    #     frappe.throw(str(settings))
+    #     return settings
     
     return None
+
 
 
 def get_branch_id(company_name: str, vendor: str) -> str | None:

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -1236,12 +1236,12 @@ def get_active_settings(doctype: str = SETTINGS_DOCTYPE_NAME, company: str = Non
             if mapped_settings:
                 return mapped_settings
         
-        return frappe.get_all(
-            doctype,
-            filters={"is_active": 1},
-            fields=["name", "company"],
-            ignore_permissions=True
-        ) or []
+        # return frappe.get_all(
+        #     doctype,
+        #     filters={"is_active": 1},
+        #     fields=["name", "company"],
+        #     ignore_permissions=True
+        # ) or []
 
     except Exception:
         frappe.log_error(frappe.get_traceback(), _("Failed to get active settings"))


### PR DESCRIPTION
This pull request makes several changes to how settings are fetched in the `kenya_compliance_via_slade/utils.py` utility functions. The main updates involve commenting out fallback logic for retrieving default company and active settings, which may affect how the application handles missing or default data.

**Settings retrieval logic changes:**

* In `get_settings`, fallback code for automatically retrieving the default company using `frappe.defaults.get_user_default("Company")` and `frappe.get_value("Company", {}, "name")` has been commented out, so the function will no longer try to infer the company name if it's not provided.
* The fallback logic for fetching any active settings from `SETTINGS_DOCTYPE_NAME` if no mapping is found has been commented out, eliminating this automatic retrieval step.

**Active settings query changes:**

* In `get_active_settings`, the code that queries for all active settings when no mapping is found has been commented out, so the function will not return any active settings by default.