### PR TITLE
refactor(settings): use company-specific settings and fix invoice payload

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/tasks.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/tasks.py
@@ -70,8 +70,8 @@ def refresh_notices(settings_name: str = None) -> None:
                 continue
 
 
-def get_timeframe() -> timedelta:
-    settings = get_settings()
+def get_timeframe(settings_name:str) -> timedelta:
+    settings = frappe.get_doc(SETTINGS_DOCTYPE_NAME, settings_name)
     if not settings:
         return timedelta(seconds=86400)
     timeframe = settings.get("sales_information_submission_timeframe", 86400) or 86400
@@ -88,7 +88,7 @@ def send_sales_invoices_information(settings_name: str = None) -> None:
     settings = frappe.get_doc(SETTINGS_DOCTYPE_NAME, settings_name)
     if not settings.get("sales_auto_submission_enabled"):
         return
-    timeframe_ago = datetime.now() - get_timeframe()
+    timeframe_ago = datetime.now() - get_timeframe(settings_name)
     all_submitted_unsent = fetch_sales_invoices(
         {
             "docstatus": 1,
@@ -136,10 +136,10 @@ def send_sales_invoices_information(settings_name: str = None) -> None:
 
 
 def handle_invoice_submission(invoices: list, action_func: callable) -> None:
-    max_tries = get_max_submission_attempts()
 
     for sales_invoice in invoices:
         doc = frappe.get_doc("Sales Invoice", sales_invoice.name, for_update=False)
+        max_tries = get_max_submission_attempts(company=doc.company)
         tries = int(doc.custom_submission_attempts or 0)
 
         if tries >= max_tries:
@@ -198,7 +198,7 @@ def fetch_scu_data(invoices: list) -> None:
         try:
             doc = frappe.get_doc("Sales Invoice", sales_invoice.name, for_update=False)
             tries = int(doc.custom_submission_attempts or 0)
-            max_tries = get_max_submission_attempts()
+            max_tries = get_max_submission_attempts(company=doc.company)
             if tries >= max_tries:
                 continue
             get_invoice_details(id=doc.custom_slade_id, document_name=doc.name)
@@ -427,7 +427,7 @@ def send_stock_information(settings_name: str) -> None:
     duration = timedelta(seconds=timeframe)
     timeframe_ago = datetime.now() - duration
     entries = fetch_stock_ledgers(timeframe_ago)  
-    max_tries = get_max_submission_attempts("Stock Ledger Entry")
+    max_tries = get_max_submission_attempts("Stock Ledger Entry", company=settings.company)
     for entry in entries:
         if int(entry.custom_submission_tries) >= max_tries:
             continue
@@ -435,7 +435,8 @@ def send_stock_information(settings_name: str) -> None:
          
 
 def fetch_stock_ledgers(timeframe_ago: datetime) -> List[Document]:
-    max_tries = get_max_submission_attempts("Stock Ledger Entry")
+    company = frappe.defaults.get_user_default("Company") or frappe.get_value("Company", {}, "name")
+    max_tries = get_max_submission_attempts("Stock Ledger Entry", company=company)
     entries = frappe.get_all(
         "Stock Ledger Entry",
         filters={

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/stock_ledger_entry.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/stock_ledger_entry.py
@@ -28,7 +28,7 @@ def on_update(doc: Document, method: str | None = None) -> None:
         return
     if not settings.get("stock_auto_submission_enabled"):
         return
-    max_tries = get_max_submission_attempts("Stock Ledger Entry")
+    max_tries = get_max_submission_attempts("Stock Ledger Entry", company=doc.company)
     if doc.custom_submission_tries and int(doc.custom_submission_tries) >= max_tries:
         return
     save_ledger_details(doc.name)
@@ -467,7 +467,7 @@ def stock_balance_on_success(response: dict, document_name: str, **kwargs) -> No
     )
 
     for sle in associated_sles:
-        max_tries = get_max_submission_attempts("Stock Ledger Entry")
+        max_tries = get_max_submission_attempts("Stock Ledger Entry", company=doc.company)
         if sle.custom_submission_tries and int(sle.custom_submission_tries) >= max_tries:
             continue
         frappe.enqueue(

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -312,10 +312,9 @@ def get_settings(company_name: str = None, branch_id: str = None, settings_name:
         
     company_name = (
         company_name
-        # or frappe.defaults.get_user_default("Company")
-        # or frappe.get_value("Company", {}, "name")
+        or frappe.defaults.get_user_default("Company")
+        or frappe.get_value("Company", {}, "name")
     )
-    
     if frappe.db.exists(
         ORGANISATION_MAPPING_DOCTYPE_NAME, 
         {"company": company_name, "is_active": 1}
@@ -329,18 +328,16 @@ def get_settings(company_name: str = None, branch_id: str = None, settings_name:
         if mapping and mapping.parent:
             return frappe.get_doc(SETTINGS_DOCTYPE_NAME, mapping.parent).as_dict()
     
-    # if frappe.db.exists(SETTINGS_DOCTYPE_NAME, {"is_active": 1}):
-    #     settings = frappe.db.get_value(
-    #         SETTINGS_DOCTYPE_NAME,
-    #         {"is_active": 1},
-    #         "*",
-    #         as_dict=True,
-    #     )
-    #     frappe.throw(str(settings))
-    #     return settings
+    if frappe.db.exists(SETTINGS_DOCTYPE_NAME, {"is_active": 1}):
+        settings = frappe.db.get_value(
+            SETTINGS_DOCTYPE_NAME,
+            {"is_active": 1},
+            "*",
+            as_dict=True,
+        )
+        return settings
     
     return None
-
 
 
 def get_branch_id(company_name: str, vendor: str) -> str | None:
@@ -1236,12 +1233,12 @@ def get_active_settings(doctype: str = SETTINGS_DOCTYPE_NAME, company: str = Non
             if mapped_settings:
                 return mapped_settings
         
-        # return frappe.get_all(
-        #     doctype,
-        #     filters={"is_active": 1},
-        #     fields=["name", "company"],
-        #     ignore_permissions=True
-        # ) or []
+        return frappe.get_all(
+            doctype,
+            filters={"is_active": 1},
+            fields=["name", "company"],
+            ignore_permissions=True
+        ) or []
 
     except Exception:
         frappe.log_error(frappe.get_traceback(), _("Failed to get active settings"))

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -310,11 +310,11 @@ def get_settings(company_name: str = None, branch_id: str = None, settings_name:
         if frappe.db.exists(SETTINGS_DOCTYPE_NAME, {"name": settings_name}):
             return frappe.get_doc(SETTINGS_DOCTYPE_NAME, settings_name).as_dict()
         
-    company_name = (
-        company_name
-        or frappe.defaults.get_user_default("Company")
-        or frappe.get_value("Company", {}, "name")
-    )
+    # company_name = (
+    #     company_name
+    #     or frappe.defaults.get_user_default("Company")
+    #     or frappe.get_value("Company", {}, "name")
+    # )
     if frappe.db.exists(
         ORGANISATION_MAPPING_DOCTYPE_NAME, 
         {"company": company_name, "is_active": 1}
@@ -328,14 +328,14 @@ def get_settings(company_name: str = None, branch_id: str = None, settings_name:
         if mapping and mapping.parent:
             return frappe.get_doc(SETTINGS_DOCTYPE_NAME, mapping.parent).as_dict()
     
-    if frappe.db.exists(SETTINGS_DOCTYPE_NAME, {"is_active": 1}):
-        settings = frappe.db.get_value(
-            SETTINGS_DOCTYPE_NAME,
-            {"is_active": 1},
-            "*",
-            as_dict=True,
-        )
-        return settings
+    # if frappe.db.exists(SETTINGS_DOCTYPE_NAME, {"is_active": 1}):
+    #     settings = frappe.db.get_value(
+    #         SETTINGS_DOCTYPE_NAME,
+    #         {"is_active": 1},
+    #         "*",
+    #         as_dict=True,
+    #     )
+    #     return settings
     
     return None
 
@@ -395,11 +395,11 @@ def build_invoice_payload(
             "quantity": qty,
             "uom": item.uom or "Pcs",
             "tax_code": tax_code,
-            "product_id": get_slade360_id(
-                "Item",
-                item.item_code,
-                settings_name,
-            ),
+            # "product_id": get_slade360_id(
+            #     "Item",
+            #     item.item_code,
+            #     settings_name,
+            # ),
         })
 
     return payload
@@ -1127,8 +1127,10 @@ def get_total_stock_balance_from_sle(sle_name: str) -> dict:
     return round(balance, 4)
 
 
-def get_max_submission_attempts(doctype: str = "Sales Invoice") -> int:
-    settings = get_settings()
+def get_max_submission_attempts(doctype: str = "Sales Invoice", company: str = None) -> int:
+    settings = get_settings(company_name=company) 
+    if not settings:
+        return 3
     if doctype == "Sales Invoice":
         tries = settings.get("maximum_sales_information_submission_attempts", 3)
     elif doctype == "Purchase Invoice":
@@ -1596,15 +1598,15 @@ def prepare_return_invoice_payload(
             base_amount = round(abs(item.get("base_amount")) or 0, 4)
             items.append({
                 "item_name": item.item_code,
-                "quantity": qty,
-                "amount": round(base_amount + tax_amount, 4),
+                "quantity": 1,
+                "amount": round(base_amount + tax_amount, 4) * qty,
             })
 
     return {
         "document_name": document_name,
         "invoice_reference": reference_number,
         "refund_reason": "13",
-        "amount": amount,
+        # "amount": amount,
         "items": items,
     }
     


### PR DESCRIPTION
This pull request introduces several improvements to how company-specific settings are handled in the background tasks and utility functions, ensuring that submission attempts and timeframes are correctly calculated based on the relevant company. Additionally, some code clean-up and minor logic adjustments have been made. The most important changes are grouped below.

**Company-aware settings and submission logic:**

* The `get_max_submission_attempts` function now accepts a `company` argument and retrieves settings specific to that company, defaulting to 3 if no settings are found. All usages of this function in background tasks and overrides now pass the company where appropriate, ensuring correct limits per company. [[1]](diffhunk://#diff-49f2f650dc9c4dd5f1c270e16a00dad0a48d0ac96ca7a22679b9c93272498ac6L1133-R1133) [[2]](diffhunk://#diff-323951094c926ff6a103f94551ce30619827d31f420fd4801029d928b5319bcaL139-R142) [[3]](diffhunk://#diff-323951094c926ff6a103f94551ce30619827d31f420fd4801029d928b5319bcaL201-R201) [[4]](diffhunk://#diff-323951094c926ff6a103f94551ce30619827d31f420fd4801029d928b5319bcaL430-R439) [[5]](diffhunk://#diff-e5439aae4bf92b0d7f8cda0b9fa38c60c678d71f59b900930a8e4498249dd5f4L31-R31) [[6]](diffhunk://#diff-e5439aae4bf92b0d7f8cda0b9fa38c60c678d71f59b900930a8e4498249dd5f4L470-R470)
* The `get_timeframe` function now requires a `settings_name` argument, and all calls to it are updated to use this, ensuring the correct timeframe is used for each company’s settings. [[1]](diffhunk://#diff-323951094c926ff6a103f94551ce30619827d31f420fd4801029d928b5319bcaL73-R74) [[2]](diffhunk://#diff-323951094c926ff6a103f94551ce30619827d31f420fd4801029d928b5319bcaL91-R91)

**Stock ledger entry handling:**

* In functions related to stock ledger entries, company information is now consistently passed when retrieving submission attempt limits, and defaults are handled more robustly. [[1]](diffhunk://#diff-323951094c926ff6a103f94551ce30619827d31f420fd4801029d928b5319bcaL430-R439) [[2]](diffhunk://#diff-e5439aae4bf92b0d7f8cda0b9fa38c60c678d71f59b900930a8e4498249dd5f4L31-R31) [[3]](diffhunk://#diff-e5439aae4bf92b0d7f8cda0b9fa38c60c678d71f59b900930a8e4498249dd5f4L470-R470)

**Utility function updates and clean-up:**

* The `get_settings` function had unused code for defaulting company names commented out, reducing confusion and potential errors. [[1]](diffhunk://#diff-49f2f650dc9c4dd5f1c270e16a00dad0a48d0ac96ca7a22679b9c93272498ac6L313-R317) [[2]](diffhunk://#diff-49f2f650dc9c4dd5f1c270e16a00dad0a48d0ac96ca7a22679b9c93272498ac6L339-L345)
* The `get_active_settings` function now returns all active settings when no mapping is found, restoring previously commented-out code for completeness.

**Minor payload and logic adjustments:**

* The `prepare_return_invoice_payload` function now sets item quantity to 1 and multiplies the amount by the original quantity, adjusting the payload logic for returns.
* The `build_invoice_payload` function has the `product_id` logic commented out, possibly for future revision or simplification.