### PR TITLE
feat: Enhance scheduled job management with robust deletion

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/navari_kra_etims_settings/navari_kra_etims_settings.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/navari_kra_etims_settings/navari_kra_etims_settings.py
@@ -84,11 +84,22 @@ class NavariKRAeTimsSettings(Document):
             task.enqueue()
 
         def disable_scheduled_job(name: str) -> None:
-            task_name = frappe.db.exists("Scheduled Job Type", name)
+            task_name = frappe.db.exists(
+                "Scheduled Job Type", {"job_name": name}
+            ) or frappe.db.exists("Scheduled Job Type", name)
             if task_name:
-                task = frappe.get_doc("Scheduled Job Type", task_name)
-                task.stopped = 1
-                task.save(ignore_permissions=True)
+                try:
+                    frappe.delete_doc(
+                        "Scheduled Job Type",
+                        task_name,
+                        force=True,
+                        ignore_permissions=True,
+                    )
+                except Exception as e:
+                    frappe.log_error(
+                        message=f"Failed to delete Scheduled Job Type '{task_name}': {e}",
+                        title="Scheduled Job Deletion Error",
+                    )
 
         task_configs = [
             {


### PR DESCRIPTION
This pull request updates the logic for disabling scheduled jobs in the `navari_kra_etims_settings.py` file. The main change is a shift from marking scheduled jobs as stopped to fully deleting them, with improved error handling for deletion failures.

**Scheduled job management improvements:**

* The `disable_scheduled_job` function now deletes the `Scheduled Job Type` record instead of just marking it as stopped, ensuring jobs are fully removed from the system.
* Enhanced error handling: if deletion fails, the error is logged using `frappe.log_error` for better traceability and debugging.
* Improved lookup for jobs to disable by checking both a dictionary query on `job_name` and a direct name match, increasing reliability when locating scheduled jobs.