### PR TITLE
fix(etims): Prevent eTIMS autofill and generation when registration is disabled

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/custom/item.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/custom/item.json
@@ -2509,7 +2509,7 @@
       "columns": 0,
       "creation": "2025-11-30 11:34:18.465919",
       "default": null,
-      "depends_on": null,
+      "depends_on": "eval: doc.custom_prevent_etims_registration != 1",
       "description": null,
       "docstatus": 0,
       "dt": "Item",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items.js
@@ -40,6 +40,7 @@ async function getEtimsSettings(frm) {
 }
 
 async function applyEtimsAutofillFields(frm) {
+  if (frm.doc.custom_prevent_etims_registration == 1) return;
   const fallbackSetting = frm.etims?.allSettings?.length
     ? frm.etims.allSettings[0].name
     : null;

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/item.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/item.py
@@ -65,8 +65,9 @@ def validate(doc: Document, method: str = None) -> None:
                 )
             )
 
-    if not doc.custom_item_code_etims:
-        doc.custom_item_code_etims = generate_custom_item_code_etims(doc)
+
+        if not doc.custom_item_code_etims:
+            doc.custom_item_code_etims = generate_custom_item_code_etims(doc)
 
 
 @frappe.whitelist()
@@ -88,7 +89,6 @@ def autofill_item_etims_fields(item_group=None, settings_name=None):
     """
 
     FIELD_LIST = [
-        "custom_prevent_etims_registration",
         "custom_taxation_type",
         "custom_item_classification",
         "custom_etims_country_of_origin",


### PR DESCRIPTION
Ensure items can be saved correctly when eTIMS registration is prevented
via the `custom_prevent_etims_registration` flag.

This fix:
- Respects the prevention flag by hiding or disabling eTIMS-related fields
- Skips client-side eTIMS autofill when registration is disabled
- Prevents server-side eTIMS item code generation if registration is blocked
- Removes the prevention flag from the list of autofillable fields to avoid
  it being overridden during save