### PR TITLE
fix(item): prevent autofill and item code generation when registration is disabled

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/custom/item.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/custom/item.json
@@ -2509,7 +2509,7 @@
       "columns": 0,
       "creation": "2025-11-30 11:34:18.465919",
       "default": null,
-      "depends_on": null,
+      "depends_on": "eval: doc.custom_prevent_etims_registration != 1",
       "description": null,
       "docstatus": 0,
       "dt": "Item",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items.js
@@ -40,6 +40,7 @@ async function getEtimsSettings(frm) {
 }
 
 async function applyEtimsAutofillFields(frm) {
+  if (frm.doc.custom_prevent_etims_registration == 1) return;
   const fallbackSetting = frm.etims?.allSettings?.length
     ? frm.etims.allSettings[0].name
     : null;

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/item.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/item.py
@@ -65,8 +65,9 @@ def validate(doc: Document, method: str = None) -> None:
                 )
             )
 
-    if not doc.custom_item_code_etims:
-        doc.custom_item_code_etims = generate_custom_item_code_etims(doc)
+
+        if not doc.custom_item_code_etims:
+            doc.custom_item_code_etims = generate_custom_item_code_etims(doc)
 
 
 @frappe.whitelist()
@@ -88,7 +89,6 @@ def autofill_item_etims_fields(item_group=None, settings_name=None):
     """
 
     FIELD_LIST = [
-        "custom_prevent_etims_registration",
         "custom_taxation_type",
         "custom_item_classification",
         "custom_etims_country_of_origin",


### PR DESCRIPTION
This pull request introduces changes to the ETIMS registration logic for items, primarily to support the new `custom_prevent_etims_registration` flag. The updates ensure that ETIMS-related fields are only autofilled or required when ETIMS registration is not prevented for an item.

Key logic and configuration changes:

**ETIMS registration logic:**

* In the client-side `applyEtimsAutofillFields` function, ETIMS autofill is now skipped if `custom_prevent_etims_registration` is set to 1, preventing unnecessary ETIMS field population for excluded items.
* On the server side, the `autofill_item_etims_fields` function no longer includes `custom_prevent_etims_registration` in its list of fields to autofill, reflecting that this flag is now used to control autofill behavior rather than being autofilled itself.

**Configuration and dependency changes:**

* In the `item.json` configuration, the dependency for the ETIMS-related field is updated so that the field is only shown when `custom_prevent_etims_registration` is not set to 1, improving the UI logic for item configuration.

**Code quality:**

* Minor code cleanup in the server-side `validate` function, improving readability.