### PR TITLE
fix(item): correct doc type in Item on_trash hook

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/item.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/item.py
@@ -71,7 +71,7 @@ def validate(doc: Document, method: str = None) -> None:
 
 
 @frappe.whitelist()
-def prevent_item_deletion(doc: dict) -> None:
+def prevent_item_deletion(doc: Document, method=None) -> None:
     if not frappe.db.exists(SETTINGS_DOCTYPE_NAME, {"is_active": 1}):
         return
     if doc.custom_item_registered == 1:  # Assuming 1 means registered, adjust as needed


### PR DESCRIPTION
The Item deletion hook was annotated to receive a dict, but Frappe passes a Document instance to all doc event handlers (on_trash, before_delete, etc.).

With typing validation enabled (Python 3.11), this mismatch caused a FrappeTypeError during Item deletion.

Updated the hook to accept a Document and access fields directly, aligning the function signature with Frappe’s document lifecycle.