### PR TITLE
fix(sales): Handle duplicate product errors during registration

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
@@ -325,7 +325,10 @@ def sales_information_submission_on_error(
 
     doc = frappe.get_doc(doctype, document_name)
     error_message = response if isinstance(response, str) else str(response)
-    if "get() returned more than one Product -- it returned 2!" in error_message:
+    if (
+        "get() returned more than one Product -- it returned 2!"
+        or "A product with this name already exists"
+    ) in error_message:
         for item in doc.items:
             perform_item_registration(item.item_code, settings_name)
 


### PR DESCRIPTION
Improve resilience of product registration by detecting additional duplicate-product error responses from the remote API.

This fix:
- Adds checks for duplicate product error messages
- Retries item registration when the API reports an existing product name
  or multiple product records
- Prevents failures caused by name-collision responses during sales information submission