### PR TITLE
fix(item): Validate and autofill required eTIMS fields

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/apis.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/apis.py
@@ -4,6 +4,7 @@ import json
 import aiohttp
 import frappe
 import frappe.defaults
+from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder import DocType
 
@@ -226,17 +227,42 @@ def perform_customer_search(request_data: str) -> None:
 @frappe.whitelist()
 def perform_item_registration(item_name: str, settings_name: str) -> dict | None:
     """Main function to handle item registration with SLADE"""
+    from ..overrides.server.item import autofill_item_etims_fields
+
     item = frappe.get_doc("Item", item_name)
 
     if not is_item_eligible_for_registration(item):
         return None
 
+    defaults = autofill_item_etims_fields(
+        item_group=item.item_group,
+        settings_name=settings_name,
+    )
+
+    updates = {}
+
+    for field in validate_required_fields(item):
+        if defaults.get(field):
+            updates[field] = defaults.get(field)
+
+    if updates:
+        frappe.db.set_value("Item", item.name, updates, update_modified=True)
+        for k, v in updates.items():
+            item.set(k, v)
+
     missing_fields = validate_required_fields(item)
     if missing_fields:
-        return None
+        frappe.throw(
+            _("Missing required ETIMS fields: {0}").format(
+                ", ".join(
+                    frappe.bold(field.replace("_", " ").title())
+                    for field in missing_fields
+                )
+            )
+        )
 
     if not item.custom_item_code_etims:
-        generate_and_set_etims_code(item)
+        generate_and_set_etims_code(item)  
 
     frappe.enqueue(
         process_request,
@@ -262,7 +288,7 @@ def validate_required_fields(item) -> list:
         "custom_item_classification",
         "custom_product_type",
         "custom_item_type",
-        "custom_etims_country_of_origin_code",
+        "custom_etims_country_of_origin",
         "custom_packaging_unit",
         "custom_unit_of_quantity",
         "custom_taxation_type",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items.js
@@ -17,7 +17,7 @@ frappe.ui.form.on(itemDoctypName, {
   custom_product_type_name: function (frm) {
     frm.set_value(
       "is_stock_item",
-      frm.doc.custom_product_type_name !== "Service" ? 1 : 0
+      frm.doc.custom_product_type_name !== "Service" ? 1 : 0,
     );
   },
 });
@@ -92,7 +92,7 @@ function setupButtons(frm) {
       __("Register Item"),
       () =>
         showCompanySelectionModal(frm, "register_item", unregisteredSettings),
-      __("eTims Actions")
+      __("eTims Actions"),
     );
   }
 
@@ -106,13 +106,13 @@ function setupButtons(frm) {
       __("Fetch Item Details"),
       () =>
         showCompanySelectionModal(frm, "fetch_item_details", registeredSetups),
-      __("eTims Actions")
+      __("eTims Actions"),
     );
 
     frm.add_custom_button(
       __("Update Item"),
       () => showCompanySelectionModal(frm, "update_item", registeredSetups),
-      __("eTims Actions")
+      __("eTims Actions"),
     );
   }
 
@@ -126,9 +126,9 @@ function setupButtons(frm) {
           registeredMappings.map((r) => ({
             name: r.etims_setup,
             company: getCompanyName(allSettings, r.etims_setup),
-          }))
+          })),
         ),
-      __("eTims Actions")
+      __("eTims Actions"),
     );
   }
 }
@@ -137,8 +137,8 @@ function showCompanySelectionModal(frm, actionType, availableSettings) {
   if (!availableSettings.length) {
     frappe.msgprint(
       __(
-        "No available eTIMS settings for this action. Please check configuration."
-      )
+        "No available eTIMS settings for this action. Please check configuration.",
+      ),
     );
     return;
   }
@@ -182,7 +182,7 @@ function executeItemAction(frm, actionType, settingName) {
 
   if (frm.doc.etims_setup_mapping) {
     const row = frm.doc.etims_setup_mapping.find(
-      (r) => r.etims_setup === settingName
+      (r) => r.etims_setup === settingName,
     );
     sladeId = row ? row.slade360_id : "";
   }

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/item.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/item.py
@@ -44,19 +44,26 @@ def validate(doc: Document, method: str = None) -> None:
                 doc.append("taxes", {"item_tax_template": template.name})
 
     if doc.custom_prevent_etims_registration != 1:
+        defaults = autofill_item_etims_fields(item_group=doc.item_group)
+
+        required_fields = {
+            "custom_etims_country_of_origin": "Country of Origin Code",
+            "custom_product_type": "Product Type",
+            "custom_item_type": "Item Type",
+            "custom_packaging_unit": "Packaging Unit Code",
+            "custom_unit_of_quantity": "Unit of Quantity Code",
+            "custom_item_classification": "Item Classification",
+            "custom_taxation_type": "Taxation Type",
+        }
+
         missing_fields = []
-        if not doc.custom_etims_country_of_origin_code:
-            missing_fields.append("Country of Origin Code")
-        if not doc.custom_product_type:
-            missing_fields.append("Product Type")
-        if not doc.custom_packaging_unit_code:
-            missing_fields.append("Packaging Unit Code")
-        if not doc.custom_unit_of_quantity_code:
-            missing_fields.append("Unit of Quantity Code")
-        if not doc.custom_item_classification:
-            missing_fields.append("Item Classification")
-        if not doc.custom_taxation_type:
-            missing_fields.append("Taxation Type")
+
+        for field, label in required_fields.items():
+            if not doc.get(field):
+                if defaults.get(field):
+                    doc.set(field, defaults.get(field))
+                else:
+                    missing_fields.append(label)
 
         if missing_fields:
             frappe.throw(
@@ -65,16 +72,15 @@ def validate(doc: Document, method: str = None) -> None:
                 )
             )
 
-
         if not doc.custom_item_code_etims:
             doc.custom_item_code_etims = generate_custom_item_code_etims(doc)
-
+            
 
 @frappe.whitelist()
 def prevent_item_deletion(doc: Document, method=None) -> None:
     if not frappe.db.exists(SETTINGS_DOCTYPE_NAME, {"is_active": 1}):
         return
-    if doc.custom_item_registered == 1:  # Assuming 1 means registered, adjust as needed
+    if doc.custom_item_registered == 1:  
         frappe.throw(_("Cannot delete registered items"))
     pass
 


### PR DESCRIPTION
Enhance item registration reliability by automatically populating and validating required eTIMS fields.

This fix:
- Auto-fills missing eTIMS metadata from configured defaults and persists
  the values to reduce manual entry and registration failures
- Validates required eTIMS fields and raises clear, user-friendly errors
  listing human-readable missing fields
- Normalizes country-of-origin field usage
- Applies minor client-side formatting fixes