### PR TITLE
fix(item): remove deprecated 'scu_item_code' from item payload

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -1669,7 +1669,7 @@ def build_item_payload(item, settings_name: str, slade_id: str = None) -> dict:
         "can_be_purchased": bool(item.is_purchase_item),
         "company_name": frappe.defaults.get_user_default("Company"),
         "code": item.item_code,
-        "scu_item_code": item.custom_item_code_etims,
+        # "scu_item_code": item.custom_item_code_etims,
         "scu_item_classification": get_slade360_id(
             ITEM_CLASSIFICATIONS_DOCTYPE_NAME,
             item.custom_item_classification,


### PR DESCRIPTION
This pull request makes a minor update to the `build_item_payload` function in `kenya_compliance_via_slade/utils.py`. The change comments out the assignment of the `scu_item_code` field in the returned payload, which previously set it to `item.custom_item_code_etims`. This field is now excluded from the payload.