### PR TITLE
fix(utils): remove deprecated 'scu_item_code' from item payload

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -1561,7 +1561,7 @@ def build_item_payload(item, settings_name: str, slade_id: str = None) -> dict:
         "can_be_purchased": bool(item.is_purchase_item),
         "company_name": frappe.defaults.get_user_default("Company"),
         "code": item.item_code,
-        "scu_item_code": item.custom_item_code_etims,
+        # "scu_item_code": item.custom_item_code_etims,
         "scu_item_classification": get_slade360_id(
             ITEM_CLASSIFICATIONS_DOCTYPE_NAME,
             item.custom_item_classification,


### PR DESCRIPTION
Comment out 'scu_item_code' in 'build_item_payload' to prevent downstream validation errors and integration mapping failures.

- Remove 'scu_item_code' from the generated item payload dictionary.
- Prevent the transmission of invalid/obsolete identifiers to external
  endpoints.
- Maintain integrity of remaining item attributes (Unit Price, Totals, etc.) to ensure payload structure remains compliant.