### PR TITLE
fix(dependencies): add 'frappe' dependency for bench tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "bs4"
 ]
 
+[tool.bench.frappe-dependencies]
+frappe = ">=15.0.0"
+
 [build-system]
 requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"


### PR DESCRIPTION
This pull request introduces a configuration update to the `pyproject.toml` file, specifically adding a new section for managing Frappe dependencies.

Dependency management:

* Added a `[tool.bench.frappe-dependencies]` section to specify that the project requires `frappe >=15.0.0`.