### PR TITLE
fix(pyproject): add frappe dependencies section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "bs4"
 ]
 
+[tool.bench.frappe-dependencies]
+frappe = ">=15.0.0"
+
 [build-system]
 requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"


### PR DESCRIPTION
This pull request makes a minor change to the `pyproject.toml` file by adding a new section specifying a dependency on `frappe` version 15.0.0 or higher.