### PR TITLE
chore(deps): restrict Frappe dependency to version 16.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 ]
 
 [tool.bench.frappe-dependencies]
-frappe = ">=15.0.0"
+frappe = ">=16.0.0,<17.0.0"
 
 [build-system]
 requires = ["flit_core >=3.4,<4"]


### PR DESCRIPTION
This pull request updates the minimum required version of the `frappe` dependency in the `pyproject.toml` file to ensure compatibility with version 16.x and prevent automatic upgrades to 17.x.

Dependency version update:

* Updated the `frappe` dependency requirement to `>=16.0.0,<17.0.0` in `pyproject.toml` to require version 16.x specifically.