### PR TITLE
fix(invoice): fetch full invoice details if scu_data is missing

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/apis.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/apis.py
@@ -1130,8 +1130,8 @@ def _process_invoice_fetch_request(
     if invoice.is_return or is_return:
         route_key = "SalesCreditNoteSaveReq"
 
-    if id:
-        request_data["id"] = id
+    if id or invoice.custom_slade_id:
+        request_data["id"] = id or invoice.custom_slade_id
     else:
         if (invoice.is_return and invoice.return_against) or (
             is_return and original_invoice_id

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
@@ -514,7 +514,7 @@ def update_invoice_info(
     settings_name: str | None = None,
     **kwargs,
 ) -> None:
-    process_invoice_response(response, document_name, doctype)
+    process_invoice_response(response, document_name, doctype, settings_name)
 
 
 def verify_and_fix_invoice_info(
@@ -547,18 +547,32 @@ def verify_and_fix_invoice_info(
     )
 
     if is_invoice_data_matching(invoice_data, data):
-        process_invoice_response(response, document_name, doctype)
+        process_invoice_response(response, document_name, doctype, settings_name)
     else:
         handle_invoice_mismatch(doc, document_name, doctype, settings_name, data)
 
 
-def process_invoice_response(response: dict, document_name: str, doctype: str) -> None:
+def process_invoice_response(response: dict, document_name: str, doctype: str,  settings_name: str | None = None) -> None:
     """Common function to process invoice response and update document"""
     data = get_response_data(response)
-    if not data or not data.get("scu_data"):
+    if not data:  
         return
-
     custom_slade_id = data.get("id")
+    slade_id = frappe.get_value(doctype, document_name, "custom_slade_id")
+
+    frappe.log_error(title="Invoice Response Data", message=f"{slade_id} {custom_slade_id} {data.get('scu_data')}")
+
+    if not slade_id and custom_slade_id and not data.get("scu_data"):
+        company =  frappe.get_value(doctype, document_name, "company")
+        frappe.enqueue(
+            "kenya_compliance_via_slade.kenya_compliance_via_slade.apis.apis.get_invoice_details",
+            id=custom_slade_id,
+            document_name=document_name,
+            invoice_type=doctype,
+            settings_name=settings_name,
+            company=company,
+        )
+
     updates = {
         "custom_slade_id": custom_slade_id,
         **map_scu_fields(
@@ -569,6 +583,9 @@ def process_invoice_response(response: dict, document_name: str, doctype: str) -
     if document_name:
         frappe.db.set_value(doctype, document_name, updates)
         frappe.publish_realtime("refresh_form", document_name)
+    
+    if not data.get("scu_data"):
+        verify_and_fix_invoice_revisions(doctype, document_name, data)
 
 
 def verify_and_fix_invoice_revisions(

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
@@ -576,7 +576,7 @@ def process_invoice_response(response: dict, document_name: str, doctype: str,  
     updates = {
         "custom_slade_id": custom_slade_id,
         **map_scu_fields(
-            data.get("scu_data"), custom_slade_id, doctype, qr_key="qr_code_url"
+            data, custom_slade_id, doctype, qr_key="qr_code_url"
         ),
     }
 
@@ -584,8 +584,6 @@ def process_invoice_response(response: dict, document_name: str, doctype: str,  
         frappe.db.set_value(doctype, document_name, updates)
         frappe.publish_realtime("refresh_form", document_name)
     
-    if not data.get("scu_data"):
-        verify_and_fix_invoice_revisions(doctype, document_name, data)
 
 
 def verify_and_fix_invoice_revisions(
@@ -878,6 +876,9 @@ def generate_and_attach_qr_code(url: str, docname: str, doctype: str) -> str:
 
 
 def map_scu_fields(data: dict, docname: str, doctype: str, qr_key: str) -> dict:
+    if not data.get("scu_data"):
+        return {}
+    data = data.get("scu_data", {})
     qr_url = data.get(qr_key)
     image_url = (
         generate_and_attach_qr_code(qr_url, docname, doctype) if qr_url else None


### PR DESCRIPTION
Implement a fallback fetch mechanism to ensure invoice records are fully populated when the initial response only contains an ID.

- Add logic to check for 'scu_data' in the invoice processing list.
- If 'scu_data' is absent, use the provided ID to trigger a full
  invoice fetch from the external service.
- Enqueue the fetch as a background job to maintain UI responsiveness.
- Ensure all fiscal attributes are recovered and synced to the local invoice record.