### PR TITLE
fix: restrict 'require_tax_id' auto-reset to Customer and Supplier

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
@@ -98,7 +98,7 @@ def update_document_mapping(
         slade_id (str): The Slade ID to set
     """
     doc = frappe.get_doc(doc_type, document_name)
-    if doc.require_tax_id and not doc.tax_id:
+    if doc_type in ["Customer", "Supplier"] and doc.require_tax_id and not doc.tax_id:
         doc.require_tax_id = 0
 
     found = False


### PR DESCRIPTION
Refine the document mapping lifecycle to ensure tax requirement logic is only applied to relevant business partner entities.

- Implement an explicit DocType check for 'Customer' and 'Supplier'.
- Prevent the 'require_tax_id' flag from being unset on Items
  or other compliance-sensitive documents.
- Eliminate potential 'AttributeError' risks for DocTypes
  lacking 'tax_id' or 'require_tax_id' fields.
- Ensure 'doc.save()' persists the refined state for all mapped entities.