### PR TITLE
fix: preserve existing onload handlers in sales invoice list v15

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice_list.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice_list.js
@@ -1,7 +1,13 @@
 const doctypeName = "Sales Invoice";
 const settingsDoctypeName = "Navari KRA eTims Settings";
 
+const _existing_onload = frappe.listview_settings[doctypeName]?.onload;
+
 frappe.listview_settings[doctypeName].onload = async function (listview) {
+  if (_existing_onload) {
+		await _existing_onload.call(this, listview);
+  }
+  
   const { message: activeSetting } = await frappe.call({
     method:
       "kenya_compliance_via_slade.kenya_compliance_via_slade.utils.get_active_settings",


### PR DESCRIPTION
This pull request updates the `onload` handler for the `Sales Invoice` list view to ensure that any previously defined `onload` logic is preserved and executed before the new logic. This change improves compatibility and prevents potential issues from overwriting existing behavior.

Enhancement to event handling:

* Modified `kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice_list.js` to call any existing `onload` handler before executing the new logic, ensuring previous customizations are retained.