### PR TITLE
feat: enforce active eTims mappings and implement validation checks

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
@@ -120,6 +120,7 @@ def update_document_mapping(
             {
                 "etims_setup": settings_name,
                 "slade360_id": slade_id,
+                "is_active": 1,
             },
         )
 

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/etims_company_setup_mapping/etims_company_setup_mapping.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/etims_company_setup_mapping/etims_company_setup_mapping.json
@@ -26,7 +26,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "is_active",
    "fieldtype": "Check",
    "in_filter": 1,
@@ -57,7 +57,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-07-07 09:27:27.684679",
+ "modified": "2026-03-13 04:44:55.505484",
  "modified_by": "Administrator",
  "module": "Kenya Compliance Via Slade",
  "name": "eTims Company Setup Mapping",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/etims_settings_organisation_mapping/etims_settings_organisation_mapping.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/etims_settings_organisation_mapping/etims_settings_organisation_mapping.json
@@ -33,7 +33,7 @@
   },
   {
    "columns": 1,
-   "default": "0",
+   "default": "1",
    "fieldname": "is_active",
    "fieldtype": "Check",
    "in_filter": 1,
@@ -103,7 +103,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-07-08 14:43:34.139979",
+ "modified": "2026-03-13 04:45:15.571454",
  "modified_by": "Administrator",
  "module": "Kenya Compliance Via Slade",
  "name": "eTims Settings Organisation Mapping",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/etims_slade360_id_mapping/etims_slade360_id_mapping.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/etims_slade360_id_mapping/etims_slade360_id_mapping.json
@@ -25,7 +25,8 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "0",
+   "allow_on_submit": 1,
+   "default": "1",
    "fieldname": "is_active",
    "fieldtype": "Check",
    "in_filter": 1,
@@ -47,7 +48,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-07-01 16:20:01.411333",
+ "modified": "2026-03-13 04:45:43.916724",
  "modified_by": "Administrator",
  "module": "Kenya Compliance Via Slade",
  "name": "eTims Slade360 ID Mapping",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/shared_overrides.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/shared_overrides.py
@@ -51,6 +51,13 @@ def generic_invoices_on_submit_override(
     ):
         return
 
+    customer_slade_id = get_slade360_id("Customer", doc.customer, settings_doc.name)
+    if not customer_slade_id:
+        frappe.msgprint(
+            f"Customer {doc.customer} is not registered. Cannot send invoice to eTims."
+        )
+        return
+
     for item in doc.items:
         item_doc = frappe.get_doc("Item", item.item_code)
         slade_id = get_slade360_id("Item", item_doc.get("name"), settings_doc.name)

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/set_etims_mappings_active.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/set_etims_mappings_active.py
@@ -1,0 +1,18 @@
+import frappe
+
+
+def execute():
+    doctypes = [
+        "eTims Slade360 ID Mapping",
+        "eTims Settings Organisation Mapping",
+        "eTims Company Setup Mapping",
+    ]
+
+    for doctype in doctypes:
+        if frappe.db.exists("DocType", doctype):
+            frappe.db.set_value(
+                doctype, {"is_active": 0}, "is_active", 1, update_modified=False
+            )
+            print(f"Successfully activated all records for {doctype}")
+        else:
+            print(f"Skipping: {doctype} does not exist in this environment.")

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -1552,11 +1552,49 @@ def get_slade360_id(doctype: str, name: str, setting: str) -> str:
             _("Document {0} with name {1} does not exist.").format(doctype, name)
         )
 
+    if not frappe.db.exists(SETTINGS_DOCTYPE_NAME, {"name": setting, "is_active": 1}):
+        frappe.throw(_("eTims Setup {0} is not active.").format(setting))
+
+    base_filters = {
+        "etims_setup": setting,
+        "parenttype": doctype,
+        "parent": name,
+    }
+
+    filters = base_filters.copy()
+    mapping_meta = frappe.get_meta(SLADE_ID_MAPPING_DOCTYPE_NAME)
+
+    if mapping_meta.has_field("is_active"):
+        filters["is_active"] = 1
+
     slade_id = frappe.db.get_value(
         SLADE_ID_MAPPING_DOCTYPE_NAME,
-        filters={"etims_setup": setting, "parenttype": doctype, "parent": name},
+        filters=filters,
         fieldname="slade360_id",
     )
+
+    if (
+        mapping_meta.has_field("is_active")
+        and not slade_id
+        and frappe.db.exists(SLADE_ID_MAPPING_DOCTYPE_NAME, base_filters)
+    ):
+        doc_link = frappe.utils.get_url_to_form(doctype, name)
+        settings_link = frappe.utils.get_url_to_form(SETTINGS_DOCTYPE_NAME, setting)
+
+        frappe.throw(
+            _(
+                '<a href="{0}" style="font-weight: bold; color: var(--text-color); text-decoration: none;">{1} "{2}"</a> '
+                "is not enabled for eTIMS submission in "
+                '<a href="{3}" style="font-weight: bold; color: var(--text-color); text-decoration: none;">{4} "{5}"</a>.'
+            ).format(
+                doc_link,
+                _(doctype),
+                name,
+                settings_link,
+                _(SETTINGS_DOCTYPE_NAME),
+                setting,
+            )
+        )
 
     return slade_id
 

--- a/kenya_compliance_via_slade/patches.txt
+++ b/kenya_compliance_via_slade/patches.txt
@@ -4,3 +4,4 @@ kenya_compliance_via_slade.kenya_compliance_via_slade.patches.drop_custom_fields
 [post_model_sync]
 # kenya_compliance_via_slade.kenya_compliance_via_slade.patches.create_connection_links # 23/07/25 
 kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_to_multi_company # 153/07/25 
+kenya_compliance_via_slade.kenya_compliance_via_slade.patches.set_etims_mappings_active # 13/03/26


### PR DESCRIPTION
This pull request introduces changes to ensure that eTims mapping records are active by default and enforces checks for active mappings before processing eTims submissions. It also adds a patch to activate all existing mapping records and improves error handling when attempting to submit invoices or retrieve mapping IDs.

**Activation defaults and enforcement**

* Changed the default value of the `is_active` field to `1` (active) in the `etims_slade360_id_mapping`, `etims_settings_organisation_mapping`, and `etims_company_setup_mapping` DocTypes, ensuring new records are active by default. [[1]](diffhunk://#diff-0308e6057af45d38d7ab00a0a1a933d2fcc8b5400bf2a103bc7b1abec83ab44cL28-R29) [[2]](diffhunk://#diff-ba1f988351e5c383233e1daf2cc09a940080301fc58898398fd6c9ba5de598c4L36-R36) [[3]](diffhunk://#diff-16b05d20ad41990dab48dc6667b646077b23e53bddfefa91fdfb7c2743f5728bL29-R29)
* Updated the mapping logic in `update_document_mapping` to set `is_active` to `1` when creating new records.

**Patch for activating existing records**

* Added a new patch `set_etims_mappings_active.py` and registered it in `patches.txt` to activate all existing mapping records by setting `is_active` to `1`. [[1]](diffhunk://#diff-1b004d5ac806878b01c3bb266fc21f5f92fa1115c5b46515c071ead6543fad00R1-R18) [[2]](diffhunk://#diff-88488cb98d156b05d3b7f28da0223182666c5a99a82dd87afd0670b78b80a2b6R7)

**Validation and error handling improvements**

* Enhanced `get_slade360_id` to check if the relevant setup is active and to throw detailed errors if mappings are not enabled for submission, including helpful links for users.
* Added validation in `generic_invoices_on_submit_override` to ensure the customer is registered before submitting an invoice to eTims, with user feedback if not.

**Meta and timestamp updates**

* Updated the `modified` timestamps in the mapping DocType JSON files to reflect the latest changes. [[1]](diffhunk://#diff-0308e6057af45d38d7ab00a0a1a933d2fcc8b5400bf2a103bc7b1abec83ab44cL50-R51) [[2]](diffhunk://#diff-ba1f988351e5c383233e1daf2cc09a940080301fc58898398fd6c9ba5de598c4L106-R106) [[3]](diffhunk://#diff-16b05d20ad41990dab48dc6667b646077b23e53bddfefa91fdfb7c2743f5728bL60-R60)