### PR TITLE
feat: centralize eTIMS auto-submission via unified cron scheduler

### DIFF
--- a/kenya_compliance_via_slade/hooks.py
+++ b/kenya_compliance_via_slade/hooks.py
@@ -246,15 +246,13 @@ doc_events = {
 # ---------------
 
 scheduler_events = {
-    "daily": [
-        "kenya_compliance_via_slade.kenya_compliance_via_slade.background_tasks.tasks.refresh_notices",
-    ],
+    "cron": {
+        "0/5 * * * *": [
+            "kenya_compliance_via_slade.kenya_compliance_via_slade.background_tasks.tasks.run_etims_autosubmission_scheduler"
+        ],
+    },
     "weekly": [
         "kenya_compliance_via_slade.kenya_compliance_via_slade.background_tasks.tasks.update_setting_passwords",
-    ],
-    "monthly": [
-        "kenya_compliance_via_slade.kenya_compliance_via_slade.background_tasks.tasks.refresh_code_lists",
-        "kenya_compliance_via_slade.kenya_compliance_via_slade.background_tasks.tasks.get_item_classification_codes",
     ],
 }
 

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/tasks.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/tasks.py
@@ -5,6 +5,7 @@ import frappe
 import frappe.defaults
 from frappe.model.document import Document
 from frappe import _
+from frappe.utils import now_datetime
 from typing import List
 
 from ..apis.api_builder import EndpointsBuilder
@@ -15,7 +16,7 @@ from ..doctype.doctype_names_mapping import (
     SETTINGS_DOCTYPE_NAME,
     WORKSTATION_DOCTYPE_NAME,
 )
-from ..utils import get_max_submission_attempts
+from ..utils import get_max_submission_attempts, get_next_run
 from .task_response_handlers import (
     operation_types_search_on_success,
     update_branches,
@@ -534,3 +535,113 @@ def search_branch_request(request_data: str | dict, settings_name: str) -> None:
         doctype="Branch",
         settings_name=settings_name,
     )
+
+
+def run_etims_autosubmission_scheduler():
+    settings_list = frappe.get_all(
+        SETTINGS_DOCTYPE_NAME,
+        filters={"is_active": 1},
+        fields=["name"],
+    )
+
+    for s in settings_list:
+        try:
+            doc = frappe.get_doc(SETTINGS_DOCTYPE_NAME, s.name)
+            process_etims_autosubmission(doc)
+        except Exception:
+            frappe.log_error(
+                f"eTims Autosubmission Scheduler Failed for {s.name}",
+                frappe.get_traceback(),
+            )
+
+
+def process_etims_autosubmission(doc):
+    now = now_datetime()
+    updated = False
+
+    if (
+        doc.sales_auto_submission_enabled
+        and doc.sales_next_run
+        and doc.sales_next_run <= now
+    ):
+        frappe.enqueue(
+            send_sales_invoices_information,
+            queue="long",
+            settings_name=doc.name,
+        )
+        doc.sales_last_run = now
+        doc.sales_next_run = get_next_run(
+            doc.sales_information_submission,
+            doc.sales_info_cron_format,
+        )
+        updated = True
+
+    if (
+        doc.purchase_auto_submission_enabled
+        and doc.purchases_next_run
+        and doc.purchases_next_run <= now
+    ):
+        frappe.enqueue(
+            send_purchase_information,
+            queue="long",
+            settings_name=doc.name,
+        )
+        doc.purchases_last_run = now
+        doc.purchases_next_run = get_next_run(
+            doc.purchase_information_submission,
+            doc.purchase_info_cron_format,
+        )
+        updated = True
+
+    if (
+        doc.stock_auto_submission_enabled
+        and doc.stock_next_run
+        and doc.stock_next_run <= now
+    ):
+        frappe.enqueue(
+            send_stock_information,
+            queue="long",
+            settings_name=doc.name,
+        )
+        doc.stock_last_run = now
+        doc.stock_next_run = get_next_run(
+            doc.stock_information_submission,
+            doc.stock_info_cron_format,
+        )
+        updated = True
+
+    if doc.notices_next_run and doc.notices_next_run <= now:
+        frappe.enqueue(
+            refresh_notices,
+            queue="long",
+            settings_name=doc.name,
+        )
+        doc.notices_last_run = now
+        doc.notices_next_run = get_next_run(
+            doc.notices_refresh_frequency,
+            doc.notices_refresh_freq_cron_format,
+        )
+        updated = True
+
+    if doc.codes_next_run and doc.codes_next_run <= now:
+        frappe.enqueue(
+            refresh_code_lists,
+            queue="long",
+            settings_name=doc.name,
+            request_data={},
+        )
+        frappe.enqueue(
+            get_item_classification_codes,
+            queue="long",
+            settings_name=doc.name,
+            request_data={},
+        )
+        doc.codes_last_run = now
+        doc.codes_next_run = get_next_run(
+            doc.codes_refresh_frequency,
+            doc.codes_refresh_freq_cron_format,
+        )
+        updated = True
+
+    if updated:
+        doc.save(ignore_permissions=True)

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/navari_kra_etims_settings/navari_kra_etims_settings.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/navari_kra_etims_settings/navari_kra_etims_settings.json
@@ -27,23 +27,33 @@
   "frequency_of_communication_with_etims_servers_section",
   "column_break_fsjl",
   "notices_refresh_frequency",
+  "notices_last_run",
+  "notices_next_run",
   "notices_refresh_freq_cron_format",
   "column_break_fudf",
   "codes_refresh_frequency",
+  "codes_last_run",
+  "codes_next_run",
   "codes_refresh_freq_cron_format",
   "section_break_kkbe",
   "sales_auto_submission_enabled",
   "sales_information_submission",
   "sales_info_cron_format",
   "max_allowed_revisions",
+  "sales_last_run",
+  "sales_next_run",
   "column_break_ifui",
   "purchase_auto_submission_enabled",
   "purchase_information_submission",
   "purchase_info_cron_format",
+  "purchases_last_run",
+  "purchases_next_run",
   "column_break_ukgx",
   "stock_auto_submission_enabled",
   "stock_information_submission",
   "stock_info_cron_format",
+  "stock_last_run",
+  "stock_next_run",
   "submission_timeframe_section",
   "sales_information_submission_timeframe",
   "maximum_sales_information_submission_attempts",
@@ -610,6 +620,72 @@
    "fieldtype": "Link",
    "label": "Product Type Code",
    "options": "Navari eTims Product Type"
+  },
+  {
+   "depends_on": "eval: doc.sales_auto_submission_enabled == 1",
+   "fieldname": "sales_last_run",
+   "fieldtype": "Datetime",
+   "label": "Sales Last Run",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.sales_auto_submission_enabled == 1",
+   "fieldname": "sales_next_run",
+   "fieldtype": "Datetime",
+   "label": "Sales Next Run",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.purchase_auto_submission_enabled == 1",
+   "fieldname": "purchases_last_run",
+   "fieldtype": "Datetime",
+   "label": "Purchases Last Run",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.purchase_auto_submission_enabled == 1",
+   "fieldname": "purchases_next_run",
+   "fieldtype": "Datetime",
+   "label": "Purchases Next Run",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.stock_auto_submission_enabled == 1",
+   "fieldname": "stock_last_run",
+   "fieldtype": "Datetime",
+   "label": "Stock Last Run",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.stock_auto_submission_enabled == 1",
+   "fieldname": "stock_next_run",
+   "fieldtype": "Datetime",
+   "label": "Stock Next Run",
+   "read_only": 1
+  },
+  {
+   "fieldname": "notices_last_run",
+   "fieldtype": "Datetime",
+   "label": "Notices Last Run",
+   "read_only": 1
+  },
+  {
+   "fieldname": "notices_next_run",
+   "fieldtype": "Datetime",
+   "label": "Notices next Run",
+   "read_only": 1
+  },
+  {
+   "fieldname": "codes_last_run",
+   "fieldtype": "Datetime",
+   "label": "Codes Last Run",
+   "read_only": 1
+  },
+  {
+   "fieldname": "codes_next_run",
+   "fieldtype": "Datetime",
+   "label": "Codes Next Run",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -621,7 +697,7 @@
    "link_fieldname": "reference_docname"
   }
  ],
- "modified": "2025-12-02 14:43:22.329617",
+ "modified": "2026-03-17 08:39:40.131286",
  "modified_by": "Administrator",
  "module": "Kenya Compliance Via Slade",
  "name": "Navari KRA eTims Settings",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/navari_kra_etims_settings/navari_kra_etims_settings.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/navari_kra_etims_settings/navari_kra_etims_settings.py
@@ -3,15 +3,11 @@ import json
 import frappe
 from frappe.model.document import Document
 
-from ...background_tasks.tasks import (
-    get_item_classification_codes,
-    refresh_code_lists,
-    refresh_notices,
-    send_purchase_information,
-    send_sales_invoices_information,
-    send_stock_information,
+from ...utils import (
+    reset_auth_password,
+    update_navari_settings_with_token,
+    get_next_run,
 )
-from ...utils import reset_auth_password, update_navari_settings_with_token
 from ...doctype.doctype_names_mapping import (
     SETTINGS_DOCTYPE_NAME,
     ORGANISATION_MAPPING_DOCTYPE_NAME,
@@ -59,109 +55,8 @@ class NavariKRAeTimsSettings(Document):
                         )
 
     def on_update(self) -> None:
-        def get_or_create_scheduled_job(
-            name: str,
-            method: str,
-            freq: Optional[str],
-            cron: Optional[str],
-            job_args: dict,
-        ) -> None:
-            task_name = frappe.db.exists("Scheduled Job Type", {"job_name": name})
-            if task_name:
-                task = frappe.get_doc("Scheduled Job Type", task_name)
-            else:
-                task = frappe.new_doc("Scheduled Job Type")
-                task.job_name = name
-                task.name = name
-
-            task.method = method
-            task.frequency = freq or task.frequency
-            if freq == "Cron" and cron:
-                task.cron_format = cron
-            task.stopped = 0
-            task.job_args = frappe.as_json(job_args)
-            task.save(ignore_permissions=True)
-            task.enqueue()
-
-        def disable_scheduled_job(name: str) -> None:
-            task_name = frappe.db.exists(
-                "Scheduled Job Type", {"job_name": name}
-            ) or frappe.db.exists("Scheduled Job Type", name)
-            if task_name:
-                try:
-                    frappe.delete_doc(
-                        "Scheduled Job Type",
-                        task_name,
-                        force=True,
-                        ignore_permissions=True,
-                    )
-                except Exception as e:
-                    frappe.log_error(
-                        message=f"Failed to delete Scheduled Job Type '{task_name}': {e}",
-                        title="Scheduled Job Deletion Error",
-                    )
-
-        task_configs = [
-            {
-                "enabled": self.sales_auto_submission_enabled == 1,
-                "name": f"{self.name}-send_sales_invoices_information",
-                "method": f"{send_sales_invoices_information.__module__}.{send_sales_invoices_information.__name__}",
-                "frequency": self.sales_information_submission,
-                "cron": self.sales_info_cron_format,
-            },
-            {
-                "enabled": self.stock_auto_submission_enabled == 1,
-                "name": f"{self.name}-send_stock_information",
-                "method": f"{send_stock_information.__module__}.{send_stock_information.__name__}",
-                "frequency": self.stock_information_submission,
-                "cron": self.stock_info_cron_format,
-            },
-            {
-                "enabled": self.purchase_auto_submission_enabled == 1,
-                "name": f"{self.name}-send_purchase_information",
-                "method": f"{send_purchase_information.__module__}.{send_purchase_information.__name__}",
-                "frequency": self.purchase_information_submission,
-                "cron": self.purchase_info_cron_format,
-            },
-            {
-                "enabled": bool(self.notices_refresh_frequency),
-                "name": f"{self.name}-refresh_notices",
-                "method": f"{refresh_notices.__module__}.{refresh_notices.__name__}",
-                "frequency": self.notices_refresh_frequency,
-                "cron": self.notices_refresh_freq_cron_format,
-            },
-            {
-                "enabled": bool(self.codes_refresh_frequency),
-                "name": f"{self.name}-refresh_code_lists",
-                "method": f"{refresh_code_lists.__module__}.{refresh_code_lists.__name__}",
-                "frequency": self.codes_refresh_frequency,
-                "cron": self.codes_refresh_freq_cron_format,
-                "with_request_data": True,
-            },
-            {
-                "enabled": bool(self.codes_refresh_frequency),
-                "name": f"{self.name}-get_item_classification_codes",
-                "method": f"{get_item_classification_codes.__module__}.{get_item_classification_codes.__name__}",
-                "frequency": self.codes_refresh_frequency,
-                "cron": self.codes_refresh_freq_cron_format,
-                "with_request_data": True,
-            },
-        ]
-
-        for config in task_configs:
-            job_args = {"settings_name": self.name}
-            if config.get("with_request_data"):
-                job_args["request_data"] = {}
-            if config["enabled"]:
-                get_or_create_scheduled_job(
-                    config["name"],
-                    config["method"],
-                    config["frequency"],
-                    config["cron"],
-                    job_args,
-                )
-            else:
-                disable_scheduled_job(config["name"])
+        self.initialize_next_runs()
+        self.cleanup_legacy_scheduled_jobs()
 
     def update_password(self) -> None:
         """Update the password for the settings document."""
@@ -170,6 +65,62 @@ class NavariKRAeTimsSettings(Document):
     def update_token(self) -> None:
         """Update the password for the settings document."""
         update_navari_settings_with_token(self.name, True)
+
+    def initialize_next_runs(self):
+        if self.sales_auto_submission_enabled and not self.sales_next_run:
+            self.sales_next_run = get_next_run(
+                self.sales_information_submission,
+                self.sales_info_cron_format,
+            )
+
+        if self.purchase_auto_submission_enabled and not self.purchases_next_run:
+            self.purchases_next_run = get_next_run(
+                self.purchase_information_submission,
+                self.purchase_info_cron_format,
+            )
+
+        if self.stock_auto_submission_enabled and not self.stock_next_run:
+            self.stock_next_run = get_next_run(
+                self.stock_information_submission,
+                self.stock_info_cron_format,
+            )
+
+        if self.notices_refresh_frequency and not self.notices_next_run:
+            self.notices_next_run = get_next_run(
+                self.notices_refresh_frequency,
+                self.notices_refresh_freq_cron_format,
+            )
+
+        if self.codes_refresh_frequency and not self.codes_next_run:
+            self.codes_next_run = get_next_run(
+                self.codes_refresh_frequency,
+                self.codes_refresh_freq_cron_format,
+            )
+
+    def cleanup_legacy_scheduled_jobs(self):
+        """Remove old Scheduled Job Types created by this settings doc"""
+
+        job_prefix = f"{self.name}-"
+
+        jobs = frappe.get_all(
+            "Scheduled Job Type",
+            filters={"job_name": ["like", f"{job_prefix}%"]},
+            pluck="name",
+        )
+
+        for job in jobs:
+            try:
+                frappe.delete_doc(
+                    "Scheduled Job Type",
+                    job,
+                    force=True,
+                    ignore_permissions=True,
+                )
+            except Exception:
+                frappe.log_error(
+                    frappe.get_traceback(),
+                    f"Failed to delete Scheduled Job Type {job}",
+                )
 
 
 @frappe.whitelist()

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -22,6 +22,7 @@ from frappe import _
 from frappe.integrations.utils import create_request_log
 from frappe.model.document import Document
 from frappe.query_builder import DocType
+from frappe.utils import now_datetime, add_to_date
 
 from .doctype.doctype_names_mapping import (
     ENVIRONMENT_SPECIFICATION_DOCTYPE_NAME,
@@ -2053,3 +2054,31 @@ def validate_kra_pin(pin: str):
 def chunked(iterable, size):
     for i in range(0, len(iterable), size):
         yield iterable[i : i + size]
+
+
+def get_next_run(frequency, cron=None):
+    now = now_datetime()
+
+    if not frequency:
+        return None
+
+    if frequency == "Hourly":
+        return add_to_date(now, hours=1)
+    elif frequency == "Daily":
+        return add_to_date(now, days=1)
+    elif frequency == "Weekly":
+        return add_to_date(now, weeks=1)
+    elif frequency == "Monthly":
+        return add_to_date(now, months=1)
+    elif frequency == "Cron" and cron:
+        try:
+            from croniter import croniter
+
+            return croniter(cron, now).get_next(datetime)
+        except ImportError:
+            frappe.log_error(
+                message="cron utility is not available", title="Missing Dependency"
+            )
+            return None
+
+    return None


### PR DESCRIPTION
Overhaul task orchestration by replacing individual Frappe schedules with a single, 5-minute heartbeat for all eTIMS submission types.

- Implement a master scheduler to iterate through active settings and enqueue Sales, Purchase, Stock, and Code syncs.
- Add '_last_run' and '_next_run' fields to eTims Settings for granular execution tracking.
- Develop 'get_next_run' utility for precise timing calculations.
- Purge legacy scheduled jobs to ensure a clean transition to the unified model.