### PR TITLE
fix: align eTIMS lookup and submission identifiers for Partners

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/apis.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/apis.py
@@ -475,10 +475,12 @@ def send_branch_customer_details(
     ):
         return
 
+    partner_name = data.customer_name if is_customer else data.supplier_name
+
     request_data = (
         {"customer_tax_pin": data.tax_id, "document_name": name}
         if hasattr(data, "tax_id") and data.tax_id not in (None, "")
-        else {"partner_name": name, "document_name": name}
+        else {"partner_name": partner_name, "document_name": name}
     )
 
     process_request(


### PR DESCRIPTION
Standardize the partner synchronization workflow by using legal names

for both existence checks and API payloads, preventing duplicates.

- Refactor 'send_branch_customer_details' to query eTIMS based on 'customer_name'

  or 'supplier_name' instead of internal IDs.