### PR TITLE
fix: update function call to verify invoice details in bulk processing

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/apis.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/apis.py
@@ -115,7 +115,7 @@ def bulk_verify_and_resend_invoices(docs_list: str, settings_name: str = None) -
     for invoice_name in invoices_to_process:
         doc = frappe.get_doc("Sales Invoice", invoice_name, for_update=False)
         frappe.enqueue(
-            get_invoice_details,
+            verify_invoice_details,
             id=None,
             document_name=doc.name,
             invoice_type="Sales Invoice",


### PR DESCRIPTION
This pull request makes a targeted change to the background processing of invoices by updating the function used for invoice verification. The code now enqueues the `verify_invoice_details` function instead of `get_invoice_details` when processing sales invoices.

- Changed the enqueued function from `get_invoice_details` to `verify_invoice_details` in the `bulk_verify_and_resend_invoices` method to ensure the correct verification logic is applied to each invoice.