### PR TITLE
refactor: enable activation toggles for eTIMS mapping on Item and Customer forms

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/custom/customer.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/custom/customer.json
@@ -181,7 +181,7 @@
       "print_hide": 0,
       "print_hide_if_no_value": 0,
       "print_width": null,
-      "read_only": 1,
+      "read_only": 0,
       "read_only_depends_on": null,
       "report_hide": 0,
       "reqd": 0,

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/custom/item.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/custom/item.json
@@ -2869,7 +2869,7 @@
       "print_hide": 0,
       "print_hide_if_no_value": 0,
       "print_width": null,
-      "read_only": 1,
+      "read_only": 0,
       "read_only_depends_on": null,
       "report_hide": 0,
       "reqd": 0,

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/etims_slade360_id_mapping/etims_slade360_id_mapping.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/etims_slade360_id_mapping/etims_slade360_id_mapping.json
@@ -18,6 +18,7 @@
    "in_list_view": 1,
    "label": "eTims Setup",
    "options": "Navari KRA eTims Settings",
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -48,7 +49,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-03-13 04:45:43.916724",
+ "modified": "2026-05-03 22:31:39.085960",
  "modified_by": "Administrator",
  "module": "Kenya Compliance Via Slade",
  "name": "eTims Slade360 ID Mapping",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/customer.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/customer.js
@@ -6,6 +6,12 @@ frappe.ui.form.on(doctype, {
 
     if (frm.is_new()) return;
 
+    let grid = frm.get_field("etims_setup_mapping").grid;
+    grid.cannot_add_rows = true;
+    grid.cannot_delete_rows = true;
+    grid.only_sortable();
+    frm.refresh_field("etims_setup_mapping");
+
     const { message: data } = await frappe.call({
       method:
         "kenya_compliance_via_slade.kenya_compliance_via_slade.utils.get_etims_action_data",
@@ -60,9 +66,9 @@ function addCustomerActionButtons(frm, data) {
           registeredMappings.map((r) => ({
             name: r.etims_setup,
             company: getCompanyName(allSettings, r.etims_setup),
-          }))
+          })),
         ),
-      __("eTims Actions")
+      __("eTims Actions"),
     );
   }
 
@@ -71,7 +77,7 @@ function addCustomerActionButtons(frm, data) {
       __("Send Customer Details"),
       () =>
         showCompanySelectionModal(frm, "send_customer", unregisteredSettings),
-      __("eTims Actions")
+      __("eTims Actions"),
     );
   }
 
@@ -85,9 +91,9 @@ function addCustomerActionButtons(frm, data) {
           registeredMappings.map((r) => ({
             name: r.etims_setup,
             company: getCompanyName(allSettings, r.etims_setup),
-          }))
+          })),
         ),
-      __("eTims Actions")
+      __("eTims Actions"),
     );
   }
 
@@ -156,7 +162,7 @@ function executeCustomerAction(frm, actionType, settingsName) {
   let sladeId = "";
   if (frm.doc.etims_setup_mapping) {
     const mappingRow = frm.doc.etims_setup_mapping.find(
-      (row) => row.etims_setup === settingsName
+      (row) => row.etims_setup === settingsName,
     );
     sladeId = mappingRow ? mappingRow.slade360_id : "";
   }

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items.js
@@ -4,6 +4,11 @@ frappe.ui.form.on(itemDoctypName, {
   refresh: async function (frm) {
     await getEtimsSettings(frm);
     await applyEtimsAutofillFields(frm);
+    let grid = frm.get_field("etims_setup_mapping").grid;
+    grid.cannot_add_rows = true;
+    grid.cannot_delete_rows = true;
+    grid.only_sortable();
+    frm.refresh_field("etims_setup_mapping");
     toggleImportedLocks(frm);
     if (!frm.is_new()) {
       setupButtons(frm);


### PR DESCRIPTION
Refine the 'eTIMS Setup Mapping' interaction within the 'Item' and 'Customer' doctypes to 'Permit' status 'Updates' while 'Locking' the 'Mapping Structure' and 'Core Identifiers' to 'Preserve' 'Compliance' integrity.

- Enable 'Edit' access for the 'eTIMS Setup Mapping' table on 'Item' and 'Customer' forms, 'Allowing' users to 'Toggle' the 'Active' status of 'Specific' entries.
- Restrict 'Structural Modifications' by 'Disabling' the 'Add Row' and 'Delete Row' capabilities, 'Ensuring' that the 'Mapping' remains 'Consistent' with 'System-Provisioned' records.
- Enforce 'Read-Only' status on the 'eTIMS Setup' field within the 'Mapping Grid', 'Preventing' the 'Alteration' of 'Linked Entities' while 'Allowing' the 'Activation' state to be 'Changed'.
- Update the 'JSON Schema' for 'Item' and 'Customer' to 'Apply' these 'Granular' UI 'Constraints', 'Improving' the 'Administrative Workflow' for 'Localized' tax 'Setup'.