### PR TITLE
fix: align Return Invoice calculations with KRA eTIMS requirements and refine eTIMS mapping

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/custom/customer.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/custom/customer.json
@@ -181,7 +181,7 @@
       "print_hide": 0,
       "print_hide_if_no_value": 0,
       "print_width": null,
-      "read_only": 1,
+      "read_only": 0,
       "read_only_depends_on": null,
       "report_hide": 0,
       "reqd": 0,

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/custom/item.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/custom/item.json
@@ -2869,7 +2869,7 @@
       "print_hide": 0,
       "print_hide_if_no_value": 0,
       "print_width": null,
-      "read_only": 1,
+      "read_only": 0,
       "read_only_depends_on": null,
       "report_hide": 0,
       "reqd": 0,

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/etims_slade360_id_mapping/etims_slade360_id_mapping.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/etims_slade360_id_mapping/etims_slade360_id_mapping.json
@@ -18,6 +18,7 @@
    "in_list_view": 1,
    "label": "eTims Setup",
    "options": "Navari KRA eTims Settings",
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -47,7 +48,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-03-17 09:56:18.851731",
+ "modified": "2026-05-03 22:44:07.484561",
  "modified_by": "Administrator",
  "module": "Kenya Compliance Via Slade",
  "name": "eTims Slade360 ID Mapping",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/customer.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/customer.js
@@ -66,9 +66,9 @@ function addCustomerActionButtons(frm, data) {
           registeredMappings.map((r) => ({
             name: r.etims_setup,
             company: getCompanyName(allSettings, r.etims_setup),
-          }))
+          })),
         ),
-      __("eTims Actions")
+      __("eTims Actions"),
     );
   }
 
@@ -77,7 +77,7 @@ function addCustomerActionButtons(frm, data) {
       __("Send Customer Details"),
       () =>
         showCompanySelectionModal(frm, "send_customer", unregisteredSettings),
-      __("eTims Actions")
+      __("eTims Actions"),
     );
   }
 
@@ -91,9 +91,9 @@ function addCustomerActionButtons(frm, data) {
           registeredMappings.map((r) => ({
             name: r.etims_setup,
             company: getCompanyName(allSettings, r.etims_setup),
-          }))
+          })),
         ),
-      __("eTims Actions")
+      __("eTims Actions"),
     );
   }
 
@@ -162,7 +162,7 @@ function executeCustomerAction(frm, actionType, settingsName) {
   let sladeId = "";
   if (frm.doc.etims_setup_mapping) {
     const mappingRow = frm.doc.etims_setup_mapping.find(
-      (row) => row.etims_setup === settingsName
+      (row) => row.etims_setup === settingsName,
     );
     sladeId = mappingRow ? mappingRow.slade360_id : "";
   }

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/customer.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/customer.js
@@ -6,6 +6,12 @@ frappe.ui.form.on(doctype, {
 
     if (frm.is_new()) return;
 
+    let grid = frm.get_field("etims_setup_mapping").grid;
+    grid.cannot_add_rows = true;
+    grid.cannot_delete_rows = true;
+    grid.only_sortable();
+    frm.refresh_field("etims_setup_mapping");
+
     const { message: data } = await frappe.call({
       method:
         "kenya_compliance_via_slade.kenya_compliance_via_slade.utils.get_etims_action_data",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items.js
@@ -22,7 +22,7 @@ frappe.ui.form.on(itemDoctypName, {
   custom_product_type_name: function (frm) {
     frm.set_value(
       "is_stock_item",
-      frm.doc.custom_product_type_name !== "Service" ? 1 : 0
+      frm.doc.custom_product_type_name !== "Service" ? 1 : 0,
     );
   },
 });
@@ -97,7 +97,7 @@ function setupButtons(frm) {
       __("Register Item"),
       () =>
         showCompanySelectionModal(frm, "register_item", unregisteredSettings),
-      __("eTims Actions")
+      __("eTims Actions"),
     );
   }
 
@@ -111,13 +111,13 @@ function setupButtons(frm) {
       __("Fetch Item Details"),
       () =>
         showCompanySelectionModal(frm, "fetch_item_details", registeredSetups),
-      __("eTims Actions")
+      __("eTims Actions"),
     );
 
     frm.add_custom_button(
       __("Update Item"),
       () => showCompanySelectionModal(frm, "update_item", registeredSetups),
-      __("eTims Actions")
+      __("eTims Actions"),
     );
   }
 
@@ -131,9 +131,9 @@ function setupButtons(frm) {
           registeredMappings.map((r) => ({
             name: r.etims_setup,
             company: getCompanyName(allSettings, r.etims_setup),
-          }))
+          })),
         ),
-      __("eTims Actions")
+      __("eTims Actions"),
     );
   }
 }
@@ -142,8 +142,8 @@ function showCompanySelectionModal(frm, actionType, availableSettings) {
   if (!availableSettings.length) {
     frappe.msgprint(
       __(
-        "No available eTIMS settings for this action. Please check configuration."
-      )
+        "No available eTIMS settings for this action. Please check configuration.",
+      ),
     );
     return;
   }
@@ -187,7 +187,7 @@ function executeItemAction(frm, actionType, settingName) {
 
   if (frm.doc.etims_setup_mapping) {
     const row = frm.doc.etims_setup_mapping.find(
-      (r) => r.etims_setup === settingName
+      (r) => r.etims_setup === settingName,
     );
     sladeId = row ? row.slade360_id : "";
   }

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/items.js
@@ -4,6 +4,11 @@ frappe.ui.form.on(itemDoctypName, {
   refresh: async function (frm) {
     await getEtimsSettings(frm);
     await applyEtimsAutofillFields(frm);
+    let grid = frm.get_field("etims_setup_mapping").grid;
+    grid.cannot_add_rows = true;
+    grid.cannot_delete_rows = true;
+    grid.only_sortable();
+    frm.refresh_field("etims_setup_mapping");
     toggleImportedLocks(frm);
     if (!frm.is_new()) {
       setupButtons(frm);

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -5,24 +5,23 @@ import re
 import secrets
 import string
 from base64 import b64encode
+from collections import defaultdict
 from datetime import datetime, timedelta
 from decimal import ROUND_DOWN, Decimal
 from io import BytesIO
 from typing import Any, Dict, List, Union
 from urllib.parse import urlencode
-from collections import defaultdict
 
 import aiohttp
+import frappe
 import qrcode
 import requests
 from aiohttp import ClientTimeout
-
-import frappe
 from frappe import _
 from frappe.integrations.utils import create_request_log
 from frappe.model.document import Document
 from frappe.query_builder import DocType
-from frappe.utils import now_datetime, add_to_date
+from frappe.utils import add_to_date, now_datetime
 
 from .doctype.doctype_names_mapping import (
     ENVIRONMENT_SPECIFICATION_DOCTYPE_NAME,

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -1926,16 +1926,15 @@ def prepare_return_invoice_payload(
             )
     else:
         for item in invoice.items:
-            tax_amount = item.get(tax_field, 0) or 0
             qty = abs(item.get("qty"))
-            base_amount = round(abs(item.get(rate_field)) or 0, 4)
+            tax_total = item.get(tax_field) or 0
+            tax_amount = abs(tax_total / qty) if qty else 0
+            base_amount = round(abs(item.get(rate_field)) or 0, 4) + tax_amount
             items.append(
                 {
                     "item_name": item.item_code,
-                    "quantity": 1,
-                    "amount": round(base_amount - tax_amount, 4)
-                    * qty
-                    * convertion_rate,
+                    "quantity": round(qty, 2),
+                    "amount": round(base_amount * convertion_rate, 4),
                 }
             )
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the Kenya Compliance Via Slade app, focusing on enhancing the handling and user experience of the eTims setup mapping for both Customer and Item doctypes. The changes include making the mapping grids non-editable from the UI, correcting read-only statuses, improving code consistency, and refining the calculation logic in invoice payload preparation.

**UI/UX Improvements for eTims Setup Mapping Grids:**
- Made the `etims_setup_mapping` child table grid on both Customer and Item forms non-editable by disabling row addition and deletion, and enabling only sorting. This helps prevent users from manually editing mappings that should be managed programmatically. [[1]](diffhunk://#diff-71cfee93e72e7c20998ac3ad4d463ff8c719a07f9f753084a3a33193847ac996R9-R14) [[2]](diffhunk://#diff-fc8afe95c2310f3d438f3a77f2f4a8f5224eab5d88950f26c3736f77953dcee1R7-R11)

**Read-only Field Adjustments:**
- Changed the `read_only` property for the `etims_setup_mapping` table in both `customer.json` and `item.json` from `1` to `0` to allow programmatic updates while keeping the UI locked down. [[1]](diffhunk://#diff-dc3f26e920f1efd4276772cf1084f61cfa83e2b368845fae24f22ad85dbc8d40L184-R184) [[2]](diffhunk://#diff-05da4c8620429d89514c22d8c1f8d07c56dc4726a196d270878fa9978848830dL2872-R2872)
- Set the `read_only` property for the `eTims Setup` field in the `etims_slade360_id_mapping` doctype to `1` to prevent editing.

**Invoice Payload Calculation Fix:**
- Updated the logic in `prepare_return_invoice_payload` to correctly compute tax and base amounts per item, ensuring accurate reporting of item quantities and amounts in return invoices.

**Code Consistency and Cleanup:**
- Improved code style and consistency in the JS overrides for customer and item forms, including trailing commas and formatting for better readability. [[1]](diffhunk://#diff-fc8afe95c2310f3d438f3a77f2f4a8f5224eab5d88950f26c3736f77953dcee1L20-R25) [[2]](diffhunk://#diff-fc8afe95c2310f3d438f3a77f2f4a8f5224eab5d88950f26c3736f77953dcee1L140-R146) [[3]](diffhunk://#diff-71cfee93e72e7c20998ac3ad4d463ff8c719a07f9f753084a3a33193847ac996L159-R165) [[4]](diffhunk://#diff-fc8afe95c2310f3d438f3a77f2f4a8f5224eab5d88950f26c3736f77953dcee1L185-R190) [[5]](diffhunk://#diff-71cfee93e72e7c20998ac3ad4d463ff8c719a07f9f753084a3a33193847ac996L63-R71) [[6]](diffhunk://#diff-71cfee93e72e7c20998ac3ad4d463ff8c719a07f9f753084a3a33193847ac996L74-R80) [[7]](diffhunk://#diff-71cfee93e72e7c20998ac3ad4d463ff8c719a07f9f753084a3a33193847ac996L88-R96) [[8]](diffhunk://#diff-fc8afe95c2310f3d438f3a77f2f4a8f5224eab5d88950f26c3736f77953dcee1L95-R100) [[9]](diffhunk://#diff-fc8afe95c2310f3d438f3a77f2f4a8f5224eab5d88950f26c3736f77953dcee1L109-R120) [[10]](diffhunk://#diff-fc8afe95c2310f3d438f3a77f2f4a8f5224eab5d88950f26c3736f77953dcee1L129-R136)
- Minor import order and cleanup in `utils.py` for clarity and to avoid circular imports.

**Metadata Update:**
- Updated the `modified` timestamp in the `etims_slade360_id_mapping.json` file to reflect the latest change.