### PR TITLE
feat:Use invoice tax_id as primary source for customer PIN with fallback to Customer record

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -448,7 +448,7 @@ def build_invoice_payload(invoice: Document, settings_name: str) -> dict:
         "document_name": invoice.name,
         "reference_number": reference_number,
         "sales_type": "credit",
-        "customer_pin": frappe.get_value("Customer", invoice.customer, "tax_id")
+        "customer_pin": invoice.tax_id or frappe.get_value("Customer", invoice.customer, "tax_id")
         or None,
         "partner_name": frappe.get_value("Customer", invoice.customer, "customer_name")
         or None,


### PR DESCRIPTION
- Prioritize invoice.tax_id if available
- Fallback to Customer.tax_id only when missing
- Avoid unnecessary database calls