### PR TITLE
fix: handle missing VAT account on Purchase Invoice validate (#202)

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/purchase_invoice.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/purchase_invoice.py
@@ -22,6 +22,16 @@ def validate(doc: Document, method: str = None) -> None:
             ["name"],
             as_dict=True,
         )
+
+        if not vat_acct:
+            frappe.throw(
+                frappe._(
+                    "No 16% VAT Tax Account found for company {0}. "
+                    "Please ensure a Tax account with account type 'Tax' "
+                    "and tax rate 16 exists."
+                ).format(doc.company)
+            )
+
         doc.set(
             "taxes",
             [
@@ -58,12 +68,6 @@ def submit_purchase_invoice(doc: Document) -> None:
         ):
             # If the submission is prevented or if the invoice number is already set, skip submission
             return
-
-        # company_name = (
-        #     doc.company
-        #     # or frappe.defaults.get_user_default("Company")
-        #     # or frappe.get_value("Company", {}, "name")
-        # )
 
         if settings_doc:
             payload = build_purchase_invoice_payload(doc, company_name)


### PR DESCRIPTION
Fixes #202

## Problem
When saving a Purchase Invoice with no taxes, the code calls
frappe.get_value() to look up a 16% VAT account. If no such account
exists for the company, it returns None, causing:

    AttributeError: 'NoneType' object has no attribute 'name'

## Fix
Added a null guard after the frappe.get_value() call. If no matching
account is found, frappe.throw() is used to surface a clear,
actionable error message to the user instead of a cryptic traceback.