### PR TITLE
fix: add patch to unhide eTIMS fields hidden by property setters

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/migrate.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/migrate.py
@@ -1,5 +1,7 @@
-from .patches.create_connection_links import update_links_for_doctypes
+from kenya_compliance_via_slade.kenya_compliance_via_slade.patches.unhide_etims_fields import (
+    cleanup_property_setters,
+)
 
 
 def after_migrate():
-    update_links_for_doctypes()
+    cleanup_property_setters()

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/unhide_etims_fields.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/unhide_etims_fields.py
@@ -1,0 +1,26 @@
+import frappe
+
+
+def execute() -> None:
+    print("Starting the unhide eTims fields patch...")
+
+    cleanup_property_setters()
+
+    print("Patch execution completed successfully.")
+
+
+def cleanup_property_setters() -> None:
+    property_setters = frappe.get_all(
+        "Property Setter",
+        filters={"module": "eTims", "property": "hidden"},
+        pluck="name",
+    )
+
+    print(f"Found {len(property_setters)} property setters to delete.")
+
+    for setter in property_setters:
+        print(f"Deleting Property Setter: {setter}")
+        frappe.delete_doc("Property Setter", setter)
+
+    frappe.db.commit()
+    print("Database changes committed successfully.")


### PR DESCRIPTION
Introduce a new 'Migration Patch' that systematically identifies and removes 'Property Setter Records' associated with the 'eTIMS Module' that enforce a 'Hidden State' on fields, ensuring relevant eTIMS fields are correctly 'Exposed' in the 'User Interface', and update the 'Migration Utility' to trigger this 'Cleanup Process' during the 'Post-Migration Phase'.

- Add patch to query and delete hidden-state property setters for eTIMS fields.
- Target property setters that enforce field visibility restrictions.
- Restore proper field exposure in UI after migration.
- Trigger cleanup automatically during post-migration phase.