### PR TITLE
fix: add eTIMS submission eligibility check for auto-submission disabled state

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -2323,6 +2323,15 @@ def analyze_etims_eligibility(invoice_name):
     if not settings_doc:
         errors.append(f"No active eTIMS settings found for company {doc.company}.")
 
+    if (
+        settings_doc
+        and not settings_doc.sales_auto_submission_enabled
+        and not doc.etims_verification_url
+    ):
+        errors.append(
+            "Sales auto submission to eTIMS is disabled and invoice has not been submitted yet."
+        )
+
     if settings_doc:
         customer_slade_id = get_etims_id(
             "Customer",


### PR DESCRIPTION
Update the 'Invoice Eligibility Analysis' to ensure that invoices cannot proceed if 'Auto-Submission' is 'Disabled' and the invoice has 'Not Yet Been Submitted' to 'eTIMS', preventing potential 'Compliance Issues' by enforcing explicit 'Verification' of submission 'Status' when automation is turned 'Off'.

- Block invoice processing when auto-submission is disabled.
- Require explicit submission verification before proceeding.
- Prevent compliance gaps due to missing manual submissions.
- Add eligibility guard for disabled automation state.