### PR TITLE
refactor: standardize supplier script naming and remove legacy code

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/bom.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/bom.js
@@ -1,7 +1,7 @@
-const doctype = "BOM";
+const doctypeName = "BOM";
 const settingsDoctypeName = "Navari KRA eTims Settings";
 
-frappe.ui.form.on(doctype, {
+frappe.ui.form.on(doctypeName, {
   refresh: async function (frm) {
     const companyName = frappe.boot.sysdefaults.company;
     const { message: activeSetting } = await frappe.call({
@@ -41,7 +41,7 @@ frappe.ui.form.on(doctype, {
               },
             });
           },
-          __("eTims Actions")
+          __("eTims Actions"),
         );
       }
     }

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/branch.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/branch.js
@@ -1,7 +1,7 @@
-const doctype = "Branch";
+const doctypeName = "Branch";
 const settingsDoctypeName = "Navari KRA eTims Settings";
 
-frappe.ui.form.on(doctype, {
+frappe.ui.form.on(doctypeName, {
   refresh: async function (frm) {
     const companyName = frappe.boot.sysdefaults.company;
     if (frm.is_new()) return;
@@ -32,7 +32,7 @@ frappe.ui.form.on(doctype, {
             },
           });
         },
-        __("eTims Actions")
+        __("eTims Actions"),
       );
     }
   },

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/customer.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/customer.js
@@ -1,6 +1,6 @@
-const doctype = "Customer";
+const doctypeName = "Customer";
 
-frappe.ui.form.on(doctype, {
+frappe.ui.form.on(doctypeName, {
   refresh: async function (frm) {
     let currency = frm.doc.default_currency || "KES";
 

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/supplier.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/supplier.js
@@ -1,7 +1,7 @@
-const doctype = "Supplier";
+const supplierDoctype = "Supplier";
 const settingsDoctypeName = "Navari KRA eTims Settings";
 
-frappe.ui.form.on(doctype, {
+frappe.ui.form.on(supplierDoctype, {
   refresh: async function (frm) {
     if (frm.is_new()) return;
     const { message: data } = await frappe.call({
@@ -19,7 +19,6 @@ frappe.ui.form.on(doctype, {
 
     if (!allSettings.length) return;
 
-    // Add action buttons based on registration status
     addSupplierActionButtons(frm, {
       allSettings,
       registeredMappings,
@@ -71,22 +70,6 @@ function addSupplierActionButtons(frm, data) {
       __("eTims Actions"),
     );
   }
-
-  // if (registeredMappings.length > 0) {
-  //   frm.add_custom_button(
-  //     __("Get Supplier Details"),
-  //     () =>
-  //       showCompanySelectionModal(
-  //         frm,
-  //         "get_supplier_details",
-  //         registeredMappings.map((r) => ({
-  //           name: r.setup_docname,
-  //           company: getCompanyName(allSettings, r.setup_docname),
-  //         }))
-  //       ),
-  //     __("eTims Actions")
-  //   );
-  // }
 }
 
 function getCompanyName(allSettings, settingName) {
@@ -101,7 +84,7 @@ function showCompanySelectionModal(frm, actionType, availableSettings) {
   }
 
   if (availableSettings.length === 1) {
-    executeCustomerAction(frm, actionType, availableSettings[0].name);
+    executeSupplierAction(frm, actionType, availableSettings[0].name);
     return;
   }
 


### PR DESCRIPTION
Standardize the 'Naming Convention' for the 'Supplier' doctype  variable to improve 'Code Clarity' and 'Readability', remove  'Redundant Code' including unused 'Comments' and commented-out  'Legacy Button Logic' to reduce 'Clutter', and correct a  'Function Reference' to ensure the modal correctly triggers the  'Supplier-Specific Action' instead of the legacy 'Customer  Action'.

- Rename doctype variable references to consistent supplier naming.
- Delete unused comment blocks and legacy button code.
- Remove commented-out legacy action references.
- Fix modal function call to use supplier action instead of customer.