### PR TITLE
feat: enhance pagination, suppress error logs, and add eTIMS toggle

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/process_request.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/process_request.py
@@ -31,7 +31,7 @@ def process_request(
     settings_name: str = None,
     company: str = None,
     queue: bool = True,
-    page_size: int = 100,
+    page_size: int = 1000,
     page: int = 1,
 ) -> str | None:
     """Create eTims Job Queue entry only. No execution is performed."""
@@ -179,7 +179,7 @@ def execute_remote_request(
     document_name: str,
     settings: dict,
     job_queue: Document | None,
-    page_size: int = 100,
+    page_size: int = 1000,
     page: int = 1,
 ) -> None:
     """

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/task_response_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/task_response_handlers.py
@@ -469,9 +469,9 @@ def update_branches(response: dict, settings_name: str, **kwargs) -> None:
         company = get_company_from_setup_mapping(cluster_id, settings_name)
 
         if not company:
-            frappe.log_error(
-                f"No company found for cluster {cluster_id}", "Branch Update Skipped"
-            )
+            # frappe.log_error(
+            #     f"No company found for cluster {cluster_id}", "Branch Update Skipped"
+            # )
             continue
 
         original_branch_name = branch_data.get("name", "").strip()

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/custom/item.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/custom/item.json
@@ -1,0 +1,32 @@
+{
+  "custom_fields": [],
+  "custom_perms": [],
+  "doctype": "Item",
+  "links": [],
+  "property_setters": [
+    {
+      "_assign": null,
+      "_comments": null,
+      "_liked_by": null,
+      "_user_tags": null,
+      "creation": "2026-06-11 22:17:36.032832",
+      "default_value": null,
+      "doc_type": "Item",
+      "docstatus": 0,
+      "doctype_or_field": "DocField",
+      "field_name": "etims_prevent_etims_registration",
+      "idx": 0,
+      "is_system_generated": 0,
+      "modified": "2026-06-11 22:17:36.032832",
+      "modified_by": "Administrator",
+      "module": "Kenya Compliance Via Slade",
+      "name": "Item-etims_prevent_etims_registration-default",
+      "owner": "Administrator",
+      "property": "default",
+      "property_type": null,
+      "row_name": null,
+      "value": "0"
+    }
+  ],
+  "sync_on_migrate": 1
+}


### PR DESCRIPTION
This pull request introduces several updates to the Kenya Compliance Via Slade project, focusing on improving API efficiency, updating error logging behavior, and adding new configuration for the `Item` doctype. The most significant changes are summarized below:

### API Parameter Updates

* Increased the default `page_size` parameter from 100 to 1000 in both the `process_request` and `execute_remote_request` functions in `process_request.py` to allow for processing larger batches per request, which should improve performance for bulk operations. [[1]](diffhunk://#diff-8c4e4fc3316f9052a6b6ad198dd9e74a368ba204505e0bd75c7ec068234e7237L34-R34) [[2]](diffhunk://#diff-8c4e4fc3316f9052a6b6ad198dd9e74a368ba204505e0bd75c7ec068234e7237L182-R182)

### Logging Behavior

* Commented out the error logging when no company is found during branch updates in the `update_branches` function in `task_response_handlers.py`, likely to reduce unnecessary log noise or handle missing companies more gracefully.

### Configuration and Customization

* Added a new JSON configuration file for the `Item` doctype (`item.json`), which introduces a property setter to set the default value of the `etims_prevent_etims_registration` field to `"0"`. This allows for easier customization and migration of this property across environments.