### PR TITLE
perf: disable intensive eTIMS data migration steps for high-volume documents

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/migrate_csf_ke_data.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/migrate_csf_ke_data.py
@@ -69,37 +69,37 @@ def execute():
         "eTims Sales Taxes and Charges Template Field Migration Failed",
     )
 
-    migrate_doctype_fields(
-        "Stock Ledger Entry",
-        {
-            "custom_submitted_successfully": "sent_to_etims",
-            "custom_submission_tries": "etims_submission_attempts",
-            "custom_slade_id": "etims_id",
-        },
-        "eTims Stock Ledger Entry Field Migration Failed",
-    )
+    # migrate_doctype_fields(
+    #     "Stock Ledger Entry",
+    #     {
+    #         "custom_submitted_successfully": "sent_to_etims",
+    #         "custom_submission_tries": "etims_submission_attempts",
+    #         "custom_slade_id": "etims_id",
+    #     },
+    #     "eTims Stock Ledger Entry Field Migration Failed",
+    # )
 
-    migrate_doctype_fields(
-        "Sales Invoice",
-        {
-            "custom_successfully_submitted": "sent_to_etims",
-            "custom_slade_id": "etims_id",
-            "custom_qr_code_url": "etims_qr_code_url",
-            "custom_submission_attempts": "etims_submission_attempts",
-            "custom_qr_code": "etims_qr_image",
-        },
-        "eTims Sales Invoice Field Migration Failed",
-    )
+    # migrate_doctype_fields(
+    #     "Sales Invoice",
+    #     {
+    #         "custom_successfully_submitted": "sent_to_etims",
+    #         "custom_slade_id": "etims_id",
+    #         "custom_qr_code_url": "etims_qr_code_url",
+    #         "custom_submission_attempts": "etims_submission_attempts",
+    #         "custom_qr_code": "etims_qr_image",
+    #     },
+    #     "eTims Sales Invoice Field Migration Failed",
+    # )
 
-    migrate_doctype_fields(
-        "Sales Invoice Item",
-        {
-            "custom_tax_amount": "etims_tax_amount",
-            "custom_base_tax_amount": "etims_base_tax_amount",
-            "custom_tax_rate": "etims_tax_rate",
-        },
-        "eTims Sales Invoice Item Field Migration Failed",
-    )
+    # migrate_doctype_fields(
+    #     "Sales Invoice Item",
+    #     {
+    #         "custom_tax_amount": "etims_tax_amount",
+    #         "custom_base_tax_amount": "etims_base_tax_amount",
+    #         "custom_tax_rate": "etims_tax_rate",
+    #     },
+    #     "eTims Sales Invoice Item Field Migration Failed",
+    # )
 
     migrate_doctype_fields(
         "Customer",
@@ -109,7 +109,7 @@ def execute():
         "eTims Customer Field Migration Failed",
     )
 
-    generate_invoice_verification_urls()
+    # generate_invoice_verification_urls()
     set_etims_submission_modes()
 
 

--- a/kenya_compliance_via_slade/patches.txt
+++ b/kenya_compliance_via_slade/patches.txt
@@ -6,5 +6,5 @@ kenya_compliance_via_slade.kenya_compliance_via_slade.patches.drop_custom_fields
 kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_to_multi_company # 153/07/25 
 kenya_compliance_via_slade.kenya_compliance_via_slade.patches.set_etims_mappings_active # 13/03/26
 kenya_compliance_via_slade.kenya_compliance_via_slade.patches.set_taxation_type_codes # 22/03/26
-kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_csf_ke_data # 03/06/2026
+kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_csf_ke_data # 13/06/2026
 kenya_compliance_via_slade.kenya_compliance_via_slade.patches.purge_invalid_etims_ledger_records # 03/06/2026


### PR DESCRIPTION
Comment out 'Field Migration' for high-volume documents like 'Stock Ledger Entries' and 'Sales Invoices' to prevent potential 'Performance Issues' or 'Timeouts' during 'Patch Execution', while disabling 'Generation' of 'Invoice Verification URLs' to focus the migration on less resource-intensive 'Customer Data' and 'Submission Settings'.

- Skip field migration for Stock Ledger Entry high-volume table.
- Skip field migration for Sales Invoice large document set.
- Disable invoice verification URL generation during patch.
- Limit migration scope to Customer data and settings only.
- Prevent transaction timeouts from high-volume processing.