### PR TITLE
fix: correct tax rate calculation in utils

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -762,7 +762,7 @@ def _get_item_tax_template_rate(template_name: str) -> float:
     """
     tax_template = frappe.get_doc("Item Tax Template", template_name)
     return (
-        sum(float(tax.etims_tax_rate or 0) for tax in tax_template.taxes)
+        sum(float(tax.tax_rate or 0) for tax in tax_template.taxes)
         if tax_template.taxes
         else 0.0
     )


### PR DESCRIPTION
Update the 'Tax Rate Retrieval Logic' to use the standard  'tax_rate' field instead of the 'ETIMS-Specific' field, ensuring  the 'Tax Template Rate Calculation' is consistent with the  'General Tax Configuration' used across the system to prevent  potential 'Discrepancies' in 'Tax Reporting'.

- Replace ETIMS-specific tax rate field with standard tax_rate.
- Align tax calculation with core system tax configuration.
- Prevent reporting mismatches from inconsistent rate sources.