### PR TITLE
fix: eTIMS processing and enhance migration resilience

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -762,7 +762,7 @@ def _get_item_tax_template_rate(template_name: str) -> float:
     """
     tax_template = frappe.get_doc("Item Tax Template", template_name)
     return (
-        sum(float(tax.etims_tax_rate or 0) for tax in tax_template.taxes)
+        sum(float(tax.tax_rate or 0) for tax in tax_template.taxes)
         if tax_template.taxes
         else 0.0
     )


### PR DESCRIPTION
This pull request includes a minor update to the tax rate calculation utility. The function now uses the standard `tax_rate` field instead of the `etims_tax_rate` field when summing tax rates for an item tax template.

- Updated the `_get_item_tax_template_rate` function in `utils.py` to sum the `tax_rate` field instead of `etims_tax_rate` when calculating the total tax rate for an item tax template.