### PR TITLE
feat: pass company context to eTIMS background tasks

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
@@ -319,6 +319,7 @@ def sales_information_submission_on_success(
         "kenya_compliance_via_slade.kenya_compliance_via_slade.background_tasks.tasks.fetch_etims_sales_invoices",
         document_name=document_name,
         settings_name=settings_name,
+        company=frappe.get_value(doctype, document_name, "company"),
         request_data={"reference_number": document_name},
         queue="long",
     )

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/tasks.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/tasks.py
@@ -675,15 +675,37 @@ def fetch_etims_sales_data(
 ) -> None:
     request_data = parse_request_data(request_data)
 
-    if invoice_type in ("Sales Invoice", "Both"):
-        fetch_etims_sales_invoices(
-            request_data, settings_name, document_name=document_name
-        )
+    if document_name:
+        sales_invoice = frappe.get_doc("Sales Invoice", document_name)
+        company = sales_invoice.company
 
-    if invoice_type in ("Credit Note", "Both"):
-        fetch_etims_credit_notes(
-            request_data, settings_name, document_name=document_name
-        )
+        if invoice_type in ("Sales Invoice", "Both"):
+            fetch_etims_sales_invoices(
+                request_data,
+                settings_name,
+                document_name=document_name,
+                company=company,
+            )
+
+        if invoice_type in ("Credit Note", "Both"):
+            fetch_etims_credit_notes(
+                request_data,
+                settings_name,
+                document_name=document_name,
+                company=company,
+            )
+
+    else:
+        settings = frappe.get_doc(SETTINGS_DOCTYPE_NAME, settings_name)
+
+        for mapping in settings.organisation_mapping:
+            company = mapping.company
+
+            if invoice_type in ("Sales Invoice", "Both"):
+                fetch_etims_sales_invoices(request_data, settings_name, company=company)
+
+            if invoice_type in ("Credit Note", "Both"):
+                fetch_etims_credit_notes(request_data, settings_name, company=company)
 
 
 @frappe.whitelist()
@@ -691,6 +713,7 @@ def fetch_etims_sales_invoices(
     request_data: str | dict = None,
     settings_name: str = None,
     document_name: str = None,
+    company: str = None,
 ) -> None:
     request_data = parse_request_data(request_data)
 
@@ -705,6 +728,7 @@ def fetch_etims_sales_invoices(
         settings_name=settings_name,
         document_name=document_name,
         handler_function=fetch_etims_sales_invoices_on_success,
+        company=company,
     )
 
 
@@ -713,6 +737,7 @@ def fetch_etims_credit_notes(
     request_data: str | dict = None,
     settings_name: str = None,
     document_name: str = None,
+    company: str = None,
 ) -> None:
     # request_data = parse_request_data(request_data)
     request_data = {}
@@ -731,6 +756,7 @@ def fetch_etims_credit_notes(
         document_name=document_name,
         handler_function=fetch_etims_credit_notes_on_success,
         page_size=50,
+        company=company,
     )
 
 

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
@@ -563,6 +563,7 @@ function addCustomButtons(frm, activeSetting, summaryData) {
           args: {
             settings_name: settings_name,
             document_name: frm.doc.name,
+            company: frm.doc.company,
             request_data: {
               reference_number: frm.doc.is_return
                 ? frm.doc.return_against


### PR DESCRIPTION
Update 'Background Task Infrastructure' to propagate the  'Company' parameter through the 'Task Execution Flow', ensuring  eTIMS 'Sales Invoice' and 'Credit Note' operations correctly  identify and scope themselves to the 'Relevant Company',  especially in 'Multi-Company Setups', by modifying the 'Task  Dispatcher' to resolve the company context from either the  'Document' or the 'Organization Mapping', and updating 'Task  Handlers' to accept and utilize this 'Context'.

- Add company parameter propagation through task execution chain.
- Resolve company context from document or mapping fallback.
- Update invoice fetch task to accept company parameter.
- Update credit note fetch task to accept company parameter.
- Support multi-company environments in background processing.