### PR TITLE
refactor: update eTIMS migration for async execution and improve UI safety

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/navari_kra_etims_settings/navari_kra_etims_settings.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/navari_kra_etims_settings/navari_kra_etims_settings.js
@@ -87,7 +87,6 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
               });
             },
             error: (error) => {
-              // Error Handling is Defered to the Server
               frappe.msgprint({
                 title: __("Error"),
                 indicator: "red",
@@ -135,7 +134,6 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
                   });
                 },
                 error: (error) => {
-                  // Error Handling is Defered to the Server
                   frappe.msgprint({
                     title: __("Error"),
                     indicator: "red",
@@ -145,7 +143,6 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
               });
             },
             error: (error) => {
-              // Error Handling is Defered to the Server
               frappe.msgprint({
                 title: __("Error"),
                 indicator: "red",
@@ -285,7 +282,6 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
       },
       __("eTims Actions"),
     );
-
     frappe.call({
       method:
         "kenya_compliance_via_slade.kenya_compliance_via_slade.utils.check_hanging_custom_fields",
@@ -293,7 +289,84 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
         let fields = r.message || [];
         if (fields.length > 0) {
           frm.add_custom_button(
-            __("Clear Hanging Custom Fields"),
+            __("Run Data Migration"),
+            function () {
+              let d = new frappe.ui.Dialog({
+                title: __("Configure Data Migration Range"),
+                fields: [
+                  {
+                    label: __("Migrate Records From"),
+                    fieldname: "from_date",
+                    fieldtype: "Date",
+                    default: frappe.datetime.add_months(
+                      frappe.datetime.get_today(),
+                      -12,
+                    ),
+                    reqd: 1,
+                    description: __(
+                      "Historical cutoff boundary for heavy transaction tables (Sales Invoice, Stock Ledger, etc.).",
+                    ),
+                  },
+                ],
+                primary_action_label: __("Start Pipeline"),
+                primary_action: function (values) {
+                  d.hide();
+
+                  frappe.show_progress(
+                    __("Migrating Legacy eTims Data"),
+                    1,
+                    100,
+                    __("Initiating background job component..."),
+                  );
+
+                  frappe.call({
+                    method:
+                      "kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_csf_ke_data.migrate",
+                    args: {
+                      from_date: values.from_date,
+                    },
+                    callback: function (response) {
+                      frappe.show_alert({
+                        title: __("Pipeline Initialized"),
+                        indicator: "green",
+                        message: __(
+                          "Background worker dispatched. Reloading context...",
+                        ),
+                      });
+
+                      frappe.msgprint({
+                        title: __("Migration Job Started"),
+                        indicator: "blue",
+                        message: __(`
+                          The migration process is running asynchronously in the background.<br><br>
+                          <b>How to Cancel / Stop:</b><br>
+                          If you need to terminate this process, you can track and stop it directly via the 
+                          <a href="/app/rq-job?job_name=%5B%22like%22%2C%22%25kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_csf_ke_data.run_heavy_migrations%25%22%5D" target="_blank" rel="noopener noreferrer" style="text-decoration: underline; font-weight: bold;">
+                            Active RQ Migration Jobs
+                          </a> view by clicking <b>Force Stop Job</b> on the running task instance under the worker queue.
+                        `),
+                      });
+                    },
+                    error: function (error) {
+                      frappe.hide_progress();
+                      frappe.msgprint({
+                        title: __("Pipeline Error"),
+                        indicator: "red",
+                        message: __(
+                          "Failed to queue background worker process. Check error logs.",
+                        ),
+                      });
+                    },
+                  });
+                },
+              });
+              d.show();
+            },
+            __("CSF KE Migration"),
+          );
+
+          frm.add_custom_button(
+            __("Clear Hanging Fields"),
             function () {
               let field_list_html = fields
                 .map(
@@ -303,9 +376,13 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
                 .join("");
 
               frappe.confirm(
-                __(
-                  `Are you sure you want to delete the following hanging custom fields?<br><br><ul style="max-height: 200px; overflow-y: auto;">${field_list_html}</ul>`,
-                ),
+                __(`
+              <div class="alert alert-warning" style="margin-bottom: 15px;">
+                <strong>⚠️ Warning:</strong> Ensure you have successfully executed the <b>Run Data Migration</b> routine first. Dropping these custom fields before running migration will result in permanent loss of legacy eTims history.
+              </div>
+              Are you sure you want to delete the following hanging custom fields?<br><br>
+              <ul style="max-height: 200px; overflow-y: auto;">${field_list_html}</ul>
+            `),
                 function () {
                   frappe.call({
                     method:
@@ -320,8 +397,8 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
                           message: __(res.message.message),
                         });
                         frm.remove_custom_button(
-                          __("Clear Hanging Custom Fields"),
-                          __("eTims Actions"),
+                          __("Clear Hanging Fields"),
+                          __("CSF KE Migration"),
                         );
                       }
                     },
@@ -329,7 +406,7 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
                 },
               );
             },
-            __("eTims Actions"),
+            __("CSF KE Migration"),
           );
         }
       },

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/migrate_csf_ke_data.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/migrate_csf_ke_data.py
@@ -1,116 +1,341 @@
 import frappe
+from frappe.utils import add_years, today
 
-from ..utils import (
-    build_verification_url,
-)
+from ..utils import build_verification_url
 
 
 def execute():
-    migrate_etims_id_mapping()
+    pass
 
-    migrate_doctype_fields(
-        "Item",
-        {
-            "custom_prevent_etims_registration": "etims_prevent_etims_registration",
-            "custom_submission_tries": "etims_submission_tries",
-            "custom_taxation_type": "etims_taxation_type",
-            "custom_taxation_type_name": "etims_taxation_type_name",
-            "custom_item_classification": "etims_item_classification",
-            "custom_item_classification_code": "etims_item_classification_code",
-            "custom_etims_country_of_origin": "etims_country_of_origin",
-            "custom_etims_country_of_origin_code": "etims_country_of_origin_code",
-            "custom_packaging_unit": "etims_packaging_unit",
-            "custom_unit_of_quantity_code": "etims_unit_of_quantity_code",
-            "custom_unit_of_quantity": "etims_unit_of_quantity",
-            "custom_packaging_unit_code": "etims_packaging_unit_code",
-            "custom_item_type": "etims_item_type",
-            "custom_product_type": "etims_product_type",
-            "custom_item_type_name": "etims_item_type_name",
-            "custom_product_type_name": "etims_product_type_name",
-        },
-        "eTims Item Field Migration Failed",
+
+@frappe.whitelist()
+def migrate(from_date=None):
+    if not from_date:
+        from_date = add_years(today(), -1)
+
+    frappe.cache().set_value(
+        "etims_migration_progress",
+        {"percent": 1, "description": "Initializing Data Migration..."},
+    )
+    frappe.enqueue(
+        method="kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_csf_ke_data.run_heavy_migrations",
+        queue="long",
+        timeout=4000,
+        now=frappe.flags.in_test,
+        from_date=from_date,
     )
 
-    migrate_doctype_fields(
-        "Item Group",
-        {
-            "custom_prevent_etims_registration": "etims_prevent_etims_registration",
-            "custom_taxation_type": "etims_taxation_type",
-            "custom_taxation_type_name": "etims_taxation_type_name",
-            "custom_item_classification": "etims_item_classification",
-            "custom_item_classification_code": "etims_item_classification_code",
-            "custom_etims_country_of_origin": "etims_country_of_origin",
-            "custom_etims_country_of_origin_code": "etims_country_of_origin_code",
-            "custom_packaging_unit": "etims_packaging_unit",
-            "custom_unit_of_quantity_code": "etims_unit_of_quantity_code",
-            "custom_unit_of_quantity": "etims_unit_of_quantity",
-            "custom_packaging_unit_code": "etims_packaging_unit_code",
-            "custom_item_type": "etims_item_type",
-            "custom_product_type": "etims_product_type",
-            "custom_item_type_name": "etims_item_type_name",
-            "custom_product_type_name": "etims_product_type_name",
-        },
-        "eTims Item Group Field Migration Failed",
+
+@frappe.whitelist()
+def get_migration_status():
+    status = frappe.cache().get_value("etims_migration_progress")
+    if not status:
+        return {"percent": 0, "description": "No active migration found."}
+    return status
+
+
+def update_migration_progress(percent, description):
+    frappe.cache().set_value(
+        "etims_migration_progress", {"percent": percent, "description": description}
+    )
+    frappe.publish_progress(
+        percent,
+        title="Migrating Legacy eTims Data",
+        description=description,
     )
 
-    migrate_doctype_fields(
-        "Item Tax Template",
-        {
-            "custom_etims_taxation_type": "etims_taxation_type",
-        },
-        "eTims Item Tax Template Field Migration Failed",
-    )
 
-    migrate_doctype_fields(
-        "Sales Taxes and Charges Template",
-        {
-            "custom_etims_taxation_type": "etims_taxation_type",
-        },
-        "eTims Sales Taxes and Charges Template Field Migration Failed",
-    )
+def run_heavy_migrations(from_date):
+    try:
+        update_migration_progress(1, "Populating Master Child Table Mapping Records...")
 
-    # migrate_doctype_fields(
-    #     "Stock Ledger Entry",
-    #     {
-    #         "custom_submitted_successfully": "sent_to_etims",
-    #         "custom_submission_tries": "etims_submission_attempts",
-    #         "custom_slade_id": "etims_id",
-    #     },
-    #     "eTims Stock Ledger Entry Field Migration Failed",
-    # )
+        update_migration_progress(20, "Re-mapping Master Target ID Configurations...")
+        reconcile_master_id_mappings()
 
-    # migrate_doctype_fields(
-    #     "Sales Invoice",
-    #     {
-    #         "custom_successfully_submitted": "sent_to_etims",
-    #         "custom_slade_id": "etims_id",
-    #         "custom_qr_code_url": "etims_qr_code_url",
-    #         "custom_submission_attempts": "etims_submission_attempts",
-    #         "custom_qr_code": "etims_qr_image",
-    #     },
-    #     "eTims Sales Invoice Field Migration Failed",
-    # )
+        migrate_doctype_fields(
+            "Item",
+            {
+                "custom_prevent_etims_registration": "etims_prevent_etims_registration",
+                "custom_submission_tries": "etims_submission_tries",
+                "custom_taxation_type": "etims_taxation_type",
+                "custom_taxation_type_name": "etims_taxation_type_name",
+                "custom_item_classification": "etims_item_classification",
+                "custom_item_classification_code": "etims_item_classification_code",
+                "custom_etims_country_of_origin": "etims_country_of_origin",
+                "custom_etims_country_of_origin_code": "etims_country_of_origin_code",
+                "custom_packaging_unit": "etims_packaging_unit",
+                "custom_unit_of_quantity_code": "etims_unit_of_quantity_code",
+                "custom_unit_of_quantity": "etims_unit_of_quantity",
+                "custom_packaging_unit_code": "etims_packaging_unit_code",
+                "custom_item_type": "etims_item_type",
+                "custom_product_type": "etims_product_type",
+                "custom_item_type_name": "etims_item_type_name",
+                "custom_product_type_name": "etims_product_type_name",
+            },
+            "eTims Item Field Migration Failed",
+            start_perc=25,
+            end_perc=35,
+            main_criterion_field="custom_item_classification_code",
+        )
 
-    # migrate_doctype_fields(
-    #     "Sales Invoice Item",
-    #     {
-    #         "custom_tax_amount": "etims_tax_amount",
-    #         "custom_base_tax_amount": "etims_base_tax_amount",
-    #         "custom_tax_rate": "etims_tax_rate",
-    #     },
-    #     "eTims Sales Invoice Item Field Migration Failed",
-    # )
+        migrate_doctype_fields(
+            "Item Group",
+            {
+                "custom_prevent_etims_registration": "etims_prevent_etims_registration",
+                "custom_taxation_type": "etims_taxation_type",
+                "custom_taxation_type_name": "etims_taxation_type_name",
+                "custom_item_classification": "etims_item_classification",
+                "custom_item_classification_code": "etims_item_classification_code",
+                "custom_etims_country_of_origin": "etims_country_of_origin",
+                "custom_etims_country_of_origin_code": "etims_country_of_origin_code",
+                "custom_packaging_unit": "etims_packaging_unit",
+                "custom_unit_of_quantity_code": "etims_unit_of_quantity_code",
+                "custom_unit_of_quantity": "etims_unit_of_quantity",
+                "custom_packaging_unit_code": "etims_packaging_unit_code",
+                "custom_item_type": "etims_item_type",
+                "custom_product_type": "etims_product_type",
+                "custom_item_type_name": "etims_item_type_name",
+                "custom_product_type_name": "etims_product_type_name",
+            },
+            "eTims Item Group Field Migration Failed",
+            start_perc=35,
+            end_perc=45,
+            main_criterion_field="custom_item_classification_code",
+        )
 
-    migrate_doctype_fields(
-        "Customer",
-        {
-            "custom_prevent_etims_registration": "etims_prevent_etims_registration",
-        },
-        "eTims Customer Field Migration Failed",
-    )
+        update_migration_progress(46, "Processing Item Tax Templates...")
+        migrate_doctype_fields(
+            "Item Tax Template",
+            {
+                "custom_etims_taxation_type": "etims_taxation_type",
+            },
+            "eTims Item Tax Template Field Migration Failed",
+            start_perc=46,
+            end_perc=48,
+            main_criterion_field="custom_etims_taxation_type",
+        )
 
-    # generate_invoice_verification_urls()
-    set_etims_submission_modes()
+        update_migration_progress(49, "Processing Sales Taxes Templates...")
+        migrate_doctype_fields(
+            "Sales Taxes and Charges Template",
+            {
+                "custom_etims_taxation_type": "etims_taxation_type",
+            },
+            "eTims Sales Taxes and Charges Template Field Migration Failed",
+            start_perc=49,
+            end_perc=52,
+            main_criterion_field="custom_etims_taxation_type",
+        )
+
+        update_migration_progress(53, "Processing Customer Master Fields...")
+        migrate_doctype_fields(
+            "Customer",
+            {
+                "custom_prevent_etims_registration": "etims_prevent_etims_registration",
+            },
+            "eTims Customer Field Migration Failed",
+            start_perc=53,
+            end_perc=60,
+            main_criterion_field="custom_prevent_etims_registration",
+        )
+
+        migrate_doctype_fields_batched(
+            "Stock Ledger Entry",
+            {
+                "custom_submitted_successfully": "sent_to_etims",
+                "custom_submission_tries": "etims_submission_attempts",
+                "custom_slade_id": "etims_id",
+            },
+            "eTims Stock Ledger Entry Field Migration Failed",
+            60,
+            75,
+            from_date=from_date,
+            date_field="posting_date",
+            main_criterion_field="custom_slade_id",
+        )
+
+        migrate_doctype_fields_batched(
+            "Sales Invoice",
+            {
+                "custom_successfully_submitted": "sent_to_etims",
+                "custom_slade_id": "etims_id",
+                "custom_qr_code_url": "etims_qr_code_url",
+                "custom_submission_attempts": "etims_submission_attempts",
+                "custom_qr_code": "etims_qr_image",
+            },
+            "eTims Sales Invoice Field Migration Failed",
+            75,
+            90,
+            from_date=from_date,
+            date_field="posting_date",
+            main_criterion_field="custom_slade_id",
+        )
+
+        migrate_doctype_fields_batched(
+            "Sales Invoice Item",
+            {
+                "custom_tax_amount": "etims_tax_amount",
+                "custom_base_tax_amount": "etims_base_tax_amount",
+                "custom_tax_rate": "etims_tax_rate",
+            },
+            "eTims Sales Invoice Item Field Migration Failed",
+            90,
+            95,
+            from_date=from_date,
+            date_field="creation",
+            main_criterion_field="custom_tax_rate",
+        )
+
+        generate_invoice_verification_urls(from_date)
+
+        update_migration_progress(98, "Finishing up submission rules settings...")
+        set_etims_submission_modes()
+
+        update_migration_progress(100, "Migration successfully finished!")
+
+    except Exception:
+        frappe.db.rollback()
+        update_migration_progress(0, "Migration stopped due to errors.")
+
+
+def reconcile_master_id_mappings():
+    if not frappe.db.exists("DocType", "eTims ID Mapping"):
+        return
+
+    doctypes = ["Customer", "Item", "Supplier"]
+    for d_idx, doctype in enumerate(doctypes, start=1):
+        if not frappe.db.exists("DocType", doctype):
+            continue
+
+        records = frappe.get_all(doctype, fields=["name"], limit_page_length=0)
+        total_records = len(records)
+        if not total_records:
+            continue
+
+        for idx, row in enumerate(records, start=1):
+            if idx % 20 == 0 or idx == total_records:
+                current_perc = int(((d_idx - 1) / len(doctypes)) * 15) + 20
+                update_migration_progress(
+                    current_perc,
+                    f"Cross-referencing {doctype} configuration structures ({idx}/{total_records})...",
+                )
+
+            try:
+                doc = frappe.get_doc(doctype, row.name)
+                setup_mappings = doc.get("etims_setup_mapping") or []
+
+                existing_global_entries = frappe.get_all(
+                    "eTims ID Mapping",
+                    filters={"parent": doc.name, "parenttype": doctype},
+                    fields=["name", "etims_id", "disabled", "setup_docname"],
+                )
+
+                seen_pairs = set()
+                for entry in existing_global_entries:
+                    pair_key = (entry.setup_docname, entry.etims_id)
+                    if pair_key in seen_pairs:
+                        frappe.delete_doc(
+                            "eTims ID Mapping", entry.name, ignore_permissions=True
+                        )
+                        continue
+                    seen_pairs.add(pair_key)
+
+                existing_global_entries = frappe.get_all(
+                    "eTims ID Mapping",
+                    filters={"parent": doc.name, "parenttype": doctype},
+                    fields=["name", "etims_id", "disabled", "setup_docname"],
+                )
+
+                if not setup_mappings:
+                    for entry in existing_global_entries:
+                        if not entry.disabled:
+                            frappe.db.set_value(
+                                "eTims ID Mapping",
+                                entry.name,
+                                "disabled",
+                                1,
+                                update_modified=False,
+                            )
+                    continue
+
+                for child in setup_mappings:
+                    child_setup = getattr(child, "etims_setup", None)
+                    child_id = getattr(child, "slade360_id", None) or getattr(
+                        child, "etims_id", None
+                    )
+                    child_active = getattr(child, "is_active", 1)
+
+                    if not child_setup or not child_id:
+                        continue
+
+                    match_found = False
+                    for entry in existing_global_entries:
+                        if (
+                            entry.setup_docname == child_setup
+                            and entry.etims_id == child_id
+                        ):
+                            match_found = True
+                            target_disabled = 0 if child_active else 1
+                            if entry.disabled != target_disabled:
+                                frappe.db.set_value(
+                                    "eTims ID Mapping",
+                                    entry.name,
+                                    "disabled",
+                                    target_disabled,
+                                    update_modified=False,
+                                )
+                            break
+
+                    if not match_found:
+                        new_mapping = frappe.get_doc(
+                            {
+                                "doctype": "eTims ID Mapping",
+                                "setup_doctype": "Navari KRA eTims Settings",
+                                "setup_docname": child_setup,
+                                "etims_id": child_id,
+                                "disabled": 0 if child_active else 1,
+                                "parent": doc.name,
+                                "parenttype": doctype,
+                                "parentfield": "etims_id_mapping",
+                            }
+                        )
+                        new_mapping.insert(ignore_permissions=True)
+
+                for entry in existing_global_entries:
+                    child_match = False
+                    for child in setup_mappings:
+                        child_setup = getattr(child, "etims_setup", None)
+                        child_id = getattr(child, "slade360_id", None) or getattr(
+                            child, "etims_id", None
+                        )
+                        if (
+                            child_setup == entry.setup_docname
+                            and child_id == entry.etims_id
+                        ):
+                            child_match = True
+                            break
+
+                    if not child_match and not entry.disabled:
+                        frappe.db.set_value(
+                            "eTims ID Mapping",
+                            entry.name,
+                            "disabled",
+                            1,
+                            update_modified=False,
+                        )
+
+                if idx % 100 == 0:
+                    frappe.db.commit()
+
+            except Exception:
+                frappe.db.rollback()
+                frappe.log_error(
+                    title=f"Mapping Synchronization Broken for {doctype} {row.name}",
+                    message=frappe.get_traceback(),
+                )
+                frappe.db.commit()
+
+        frappe.db.commit()
 
 
 def get_valid_field_map(doctype, field_map):
@@ -124,21 +349,110 @@ def get_valid_field_map(doctype, field_map):
     return valid_map
 
 
-def migrate_doctype_fields(doctype, field_map, error_title):
+def migrate_doctype_fields(
+    doctype, field_map, error_title, start_perc, end_perc, main_criterion_field=None
+):
     valid_field_map = get_valid_field_map(doctype, field_map)
     if not valid_field_map:
         return
 
+    filters = {}
+    if main_criterion_field and frappe.db.has_column(doctype, main_criterion_field):
+        filters[main_criterion_field] = ("is", "set")
+
     records = frappe.get_all(
         doctype,
+        filters=filters,
         fields=["name"] + list(valid_field_map.keys()),
         limit_page_length=0,
     )
+    total_records = len(records)
+    if not total_records:
+        return
+
+    perc_range = end_perc - start_perc
 
     for idx, record in enumerate(records, start=1):
+        if idx % 25 == 0 or idx == total_records:
+            progress_perc = start_perc + int((idx / total_records) * perc_range)
+            update_migration_progress(
+                progress_perc,
+                f"Processing {doctype} metadata registers ({idx}/{total_records})...",
+            )
+
         try:
             update_values = {}
+            for src, target in valid_field_map.items():
+                value = getattr(record, src, None)
+                if value is not None:
+                    update_values[target] = value
 
+            if not update_values:
+                continue
+
+            frappe.db.set_value(
+                doctype,
+                record.name,
+                update_values,
+                update_modified=False,
+            )
+
+            if idx % 500 == 0:
+                frappe.db.commit()
+
+        except Exception:
+            frappe.db.rollback()
+            frappe.log_error(
+                title=error_title,
+                message=frappe.get_traceback(),
+            )
+            frappe.db.commit()
+
+    frappe.db.commit()
+
+
+def migrate_doctype_fields_batched(
+    doctype,
+    field_map,
+    error_title,
+    start_perc,
+    end_perc,
+    from_date=None,
+    date_field="posting_date",
+    main_criterion_field=None,
+):
+    valid_field_map = get_valid_field_map(doctype, field_map)
+    if not valid_field_map:
+        return
+
+    filters = {}
+    if from_date and frappe.db.has_column(doctype, date_field):
+        filters[date_field] = (">=", from_date)
+    if main_criterion_field and frappe.db.has_column(doctype, main_criterion_field):
+        filters[main_criterion_field] = ("is", "set")
+
+    records = frappe.get_all(
+        doctype,
+        filters=filters,
+        fields=["name"] + list(valid_field_map.keys()),
+        limit_page_length=0,
+    )
+    total_records = len(records)
+    if not total_records:
+        return
+
+    perc_range = end_perc - start_perc
+
+    for idx, record in enumerate(records, start=1):
+        if idx % 50 == 0 or idx == total_records:
+            progress_perc = start_perc + int((idx / total_records) * perc_range)
+            update_migration_progress(
+                progress_perc,
+                f"Updating {doctype} rows ({idx}/{total_records})...",
+            )
+
+        try:
+            update_values = {}
             for src, target in valid_field_map.items():
                 value = getattr(record, src, None)
                 if value is not None:
@@ -168,80 +482,32 @@ def migrate_doctype_fields(doctype, field_map, error_title):
     frappe.db.commit()
 
 
-def migrate_etims_id_mapping():
-    if not frappe.db.exists(
-        "DocType", "eTims Slade360 ID Mapping"
-    ) or not frappe.db.exists("DocType", "eTims ID Mapping"):
-        return
+def generate_invoice_verification_urls(from_date=None):
+    filters = {
+        "docstatus": 1,
+        "etims_id": ("is", "set"),
+    }
+    if from_date:
+        filters["posting_date"] = (">=", from_date)
 
-    old_rows = frappe.get_all(
-        "eTims Slade360 ID Mapping",
-        fields=[
-            "name",
-            "parent",
-            "parenttype",
-            "etims_setup",
-            "slade360_id",
-            "is_active",
-        ],
-        limit_page_length=0,
-    )
-
-    for idx, row in enumerate(old_rows, start=1):
-        try:
-            exists = frappe.db.exists(
-                "eTims ID Mapping",
-                {
-                    "setup_doctype": "Navari KRA eTims Settings",
-                    "setup_docname": row.etims_setup,
-                    "etims_id": row.slade360_id,
-                },
-            )
-
-            if exists:
-                continue
-
-            doc = frappe.get_doc(
-                {
-                    "doctype": "eTims ID Mapping",
-                    "setup_doctype": "Navari KRA eTims Settings",
-                    "setup_docname": row.etims_setup,
-                    "etims_id": row.slade360_id,
-                    "disabled": 0 if row.is_active else 1,
-                    "parent": row.parent,
-                    "parenttype": row.parenttype,
-                    "parentfield": "etims_id_mapping",
-                }
-            )
-
-            doc.insert(ignore_permissions=True)
-
-            if idx % 1000 == 0:
-                frappe.db.commit()
-
-        except Exception:
-            frappe.db.rollback()
-            frappe.log_error(
-                title="eTims ID Mapping Migration Failed",
-                message=frappe.get_traceback(),
-            )
-            frappe.db.commit()
-
-    frappe.db.commit()
-
-
-def generate_invoice_verification_urls():
     invoices = frappe.get_all(
         "Sales Invoice",
-        filters={
-            "docstatus": 1,
-            "etims_verification_url": ["or", ["is", "not set"], ["=", ""]],
-        },
+        filters=filters,
         fields=["name"],
         limit_page_length=0,
     )
+    total_records = len(invoices)
+    if not total_records:
+        return
 
     for idx, invoice in enumerate(invoices, start=1):
+        if idx % 50 == 0 or idx == total_records:
+            progress_perc = 95 + int((idx / total_records) * 3)
+            update_migration_progress(
+                progress_perc,
+                f"Compiling verification URLs ({idx}/{total_records})...",
+            )
+
         try:
             doc = frappe.get_doc("Sales Invoice", invoice.name)
             url = build_verification_url(doc)
@@ -254,7 +520,7 @@ def generate_invoice_verification_urls():
                     update_modified=False,
                 )
 
-            if idx % 1000 == 0:
+            if idx % 500 == 0:
                 frappe.db.commit()
 
         except Exception:

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -2402,8 +2402,18 @@ def build_verification_url(doc) -> str:
     creation = get_datetime(doc.creation) if doc.creation else None
 
     key = creation.strftime("%Y%m%d%H%M%S%f") if creation else ""
+    base_url = frappe.utils.get_url()
 
-    return f"/invoice-verification?id={quote(str(doc.name))}&key={quote(key)}"
+    parsed_url = urlparse(base_url)
+
+    if parsed_url.hostname:
+        if not (
+            parsed_url.hostname == "localhost"
+            or parsed_url.hostname.replace(".", "").isdigit()
+        ):
+            base_url = f"{parsed_url.scheme}://{parsed_url.hostname}"
+
+    return f"{base_url}/invoice-verification?id={quote(str(doc.name))}&key={quote(key)}"
 
 
 @frappe.whitelist()

--- a/kenya_compliance_via_slade/patches.txt
+++ b/kenya_compliance_via_slade/patches.txt
@@ -6,5 +6,5 @@ kenya_compliance_via_slade.kenya_compliance_via_slade.patches.drop_custom_fields
 kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_to_multi_company # 153/07/25 
 kenya_compliance_via_slade.kenya_compliance_via_slade.patches.set_etims_mappings_active # 13/03/26
 kenya_compliance_via_slade.kenya_compliance_via_slade.patches.set_taxation_type_codes # 22/03/26
-kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_csf_ke_data # 12/06/2026
+# kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_csf_ke_data # 12/06/2026
 kenya_compliance_via_slade.kenya_compliance_via_slade.patches.purge_invalid_etims_ledger_records # 08/06/2026


### PR DESCRIPTION
This pull request enhances the user experience and safety of the data migration and custom field cleanup routines in the Navari KRA eTims Settings UI, and improves the construction of verification URLs. The changes introduce a guided data migration dialog with date range selection, clearer warnings to prevent accidental data loss, and more robust error handling. Additionally, the invoice verification links now include the full site URL for better compatibility.

**UI/UX Improvements for Data Migration and Field Cleanup:**

* Added a new "Run Data Migration" button that opens a dialog to configure a migration date range, initiates a background job, and provides user feedback on job status.
* Changed the "Clear Hanging Custom Fields" button to "Clear Hanging Fields" and moved it under a new "CSF KE Migration" group for better organization. [[1]](diffhunk://#diff-767ea2f3c4805c5aee77a3820f1ecd7a679c64ee3ba264c25d23f59a7a5dd70bL288-R369) [[2]](diffhunk://#diff-767ea2f3c4805c5aee77a3820f1ecd7a679c64ee3ba264c25d23f59a7a5dd70bL323-R409)
* Added a prominent warning to the field deletion confirmation dialog, instructing users to run the migration first to avoid permanent data loss.

**Error Handling Enhancements:**

* Removed comments deferring error handling to the server and replaced them with explicit user-facing error messages via `frappe.msgprint`. [[1]](diffhunk://#diff-767ea2f3c4805c5aee77a3820f1ecd7a679c64ee3ba264c25d23f59a7a5dd70bL90) [[2]](diffhunk://#diff-767ea2f3c4805c5aee77a3820f1ecd7a679c64ee3ba264c25d23f59a7a5dd70bL138) [[3]](diffhunk://#diff-767ea2f3c4805c5aee77a3820f1ecd7a679c64ee3ba264c25d23f59a7a5dd70bL148)

**Verification URL Construction:**

* Updated the `build_verification_url` function to prepend the full site URL (excluding port and path if not localhost or an IP), ensuring invoice verification links are valid in different deployment environments.

**Patch Management:**

* Commented out the `migrate_csf_ke_data` patch in `patches.txt` to prevent it from running automatically.