### PR TITLE
refactor: update eTIMS UI and backend for data migration and company support

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/api_builder.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/api_builder.py
@@ -34,6 +34,7 @@ class BaseEndpointsBuilder:
         self._observers: list[ErrorObserver] = []
         self._doctype: str | Document | None = None
         self._document_name: str | None = None
+        self._company: str | None = None
 
     @property
     def integration_request(self) -> str | Document | None:
@@ -70,6 +71,15 @@ class BaseEndpointsBuilder:
     @document_name.setter
     def document_name(self, value: str | None) -> None:
         self._document_name = value
+
+    @property
+    def company(self) -> str | None:
+        """Company associated with the current request."""
+        return self._company
+
+    @company.setter
+    def company(self, value: str | None) -> None:
+        self._company = value
 
     def attach(self, observer: "ErrorObserver") -> None:
         """
@@ -334,6 +344,7 @@ class EndpointsBuilder(BaseEndpointsBuilder):
                     response_data,
                     self.doctype,
                     self.document_name,
+                    self.company,
                 )
             else:
                 self._handle_error(
@@ -341,6 +352,7 @@ class EndpointsBuilder(BaseEndpointsBuilder):
                     response_data,
                     self.doctype,
                     self.document_name,
+                    self.company,
                 )
 
                 if response.status_code == 401 and not retrying:
@@ -570,6 +582,7 @@ class EndpointsBuilder(BaseEndpointsBuilder):
         response_data: dict | str | bytes | None,
         doctype: str | None,
         document_name: str | None,
+        company: str | None = None,
     ) -> None:
         """
         Handle a 200/201 response.
@@ -582,6 +595,7 @@ class EndpointsBuilder(BaseEndpointsBuilder):
             response_data: Parsed response body.
             doctype: Reference doctype.
             document_name: Reference document name.
+            company: Company associated with the request.
         """
         frappe.db.set_value(
             "Integration Request",
@@ -596,6 +610,7 @@ class EndpointsBuilder(BaseEndpointsBuilder):
             doctype=doctype,
             payload=self.payload,
             settings_name=self.settings.name,
+            company=company,
         )
 
         current_page = (
@@ -635,6 +650,7 @@ class EndpointsBuilder(BaseEndpointsBuilder):
         response_data: dict | str | bytes | None,
         doctype: str | None,
         document_name: str | None,
+        company: str | None = None,
     ) -> None:
         """
         Handle a non-2xx response.
@@ -650,6 +666,7 @@ class EndpointsBuilder(BaseEndpointsBuilder):
             response_data: Parsed response body.
             doctype: Reference doctype.
             document_name: Reference document name.
+            company: Company associated with the request.
         """
         parsed_url = parse.urlparse(self.url)
 
@@ -694,6 +711,7 @@ class EndpointsBuilder(BaseEndpointsBuilder):
                 document_name=document_name,
                 payload=self.payload,
                 settings_name=self.settings.name,
+                company=company,
             )
 
 

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/process_request.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/process_request.py
@@ -119,6 +119,7 @@ def process_request(
                     job_queue=None,
                     page_size=page_size,
                     page=page,
+                    company=company_name,
                 )
 
     except Exception:
@@ -181,6 +182,7 @@ def execute_remote_request(
     job_queue: Document | None,
     page_size: int = 1000,
     page: int = 1,
+    company: str = None,
 ) -> None:
     """
     Configure ``EndpointsBuilder`` and issue the remote HTTP call.
@@ -217,6 +219,7 @@ def execute_remote_request(
     endpoints_builder.document_name = document_name
     endpoints_builder.page_size = page_size
     endpoints_builder.page = page
+    endpoints_builder.company = company
 
     response = endpoints_builder.make_remote_call()
 

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
@@ -319,6 +319,7 @@ def sales_information_submission_on_success(
         "kenya_compliance_via_slade.kenya_compliance_via_slade.background_tasks.tasks.fetch_etims_sales_invoices",
         document_name=document_name,
         settings_name=settings_name,
+        company=frappe.get_value(doctype, document_name, "company"),
         request_data={"reference_number": document_name},
         queue="long",
     )

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/task_response_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/task_response_handlers.py
@@ -738,8 +738,176 @@ def update_clusters(response: dict, settings_name: str, **kwargs) -> None:
     # })
 
 
+def fetch_etims_sales_invoices_on_success(
+    response: dict, company: str, **kwargs
+) -> None:
+    data = response.get("results")
+    if not data or not isinstance(data, list):
+        return
+
+    settings_name = kwargs.get("settings_name")
+    if not settings_name:
+        frappe.log_error(
+            title="eTIMS Fetch Error", message="Settings name not provided in kwargs"
+        )
+        return
+
+    errors = []
+    processed_ids = set()
+
+    for invoice_data in data:
+        try:
+            slade_id = invoice_data.get("id")
+            if slade_id in processed_ids:
+                errors.append(
+                    {
+                        "document": invoice_data.get(
+                            "document_number", "Unknown Document"
+                        ),
+                        "etims_id": slade_id,
+                        "error": "Duplicate record in same batch",
+                        "type": "Sales Invoice",
+                    }
+                )
+                continue
+
+            process_single_etims_entry(
+                invoice_data, "Sales Invoice", settings_name, company=company
+            )
+            processed_ids.add(slade_id)
+
+            credit_notes = invoice_data.get("credit_notes") or []
+            for cn_data in credit_notes:
+                cn_slade_id = cn_data.get("id")
+                if cn_slade_id in processed_ids:
+                    errors.append(
+                        {
+                            "document": cn_data.get(
+                                "document_number", "Unknown Document"
+                            ),
+                            "etims_id": cn_slade_id,
+                            "error": "Duplicate record in same batch",
+                            "type": "Credit Note",
+                        }
+                    )
+                    continue
+
+                process_single_etims_entry(
+                    cn_data, "Credit Note", settings_name, company=company
+                )
+                processed_ids.add(cn_slade_id)
+
+        except Exception as e:
+            doc_ref = invoice_data.get("document_number", "Unknown Document")
+            error_detail = {
+                "document": doc_ref,
+                "etims_id": invoice_data.get("id"),
+                "error": str(e),
+                "traceback": frappe.get_traceback(),
+                "type": "Sales Invoice",
+            }
+            errors.append(error_detail)
+
+            frappe.log_error(
+                title=f"eTIMS Sync Error - {doc_ref}",
+                message=f"Error: {str(e)}\nTraceback: {frappe.get_traceback()}",
+            )
+
+    if errors:
+        save_etims_sync_errors(errors, "Sales Invoice", settings_name)
+
+
+def fetch_etims_credit_notes_on_success(response: dict, company: str, **kwargs) -> None:
+    data = response.get("results")
+    if not data or not isinstance(data, list):
+        return
+
+    settings_name = kwargs.get("settings_name")
+    if not settings_name:
+        frappe.log_error(
+            title="eTIMS Fetch Error", message="Settings name not provided in kwargs"
+        )
+        return
+
+    errors = []
+    processed_ids = set()
+
+    for cn_data in data:
+        try:
+            slade_id = cn_data.get("id")
+            if slade_id in processed_ids:
+                errors.append(
+                    {
+                        "document": cn_data.get("document_number", "Unknown Document"),
+                        "etims_id": slade_id,
+                        "error": "Duplicate record in same batch",
+                        "type": "Credit Note",
+                    }
+                )
+                continue
+
+            process_single_etims_entry(
+                cn_data, "Credit Note", settings_name, company=company
+            )
+            processed_ids.add(slade_id)
+
+        except Exception as e:
+            doc_ref = cn_data.get("document_number", "Unknown Document")
+            error_detail = {
+                "document": doc_ref,
+                "etims_id": cn_data.get("id"),
+                "error": str(e),
+                "traceback": frappe.get_traceback(),
+                "type": "Credit Note",
+            }
+            errors.append(error_detail)
+
+            frappe.log_error(
+                title=f"eTIMS Sync Error - {doc_ref}",
+                message=f"Error: {str(e)}\nTraceback: {frappe.get_traceback()}",
+            )
+
+    if errors:
+        save_etims_sync_errors(errors, "Credit Note", settings_name)
+
+
+def save_etims_sync_errors(errors: list, entry_type: str, settings_name: str) -> None:
+    if not errors:
+        return
+
+    try:
+        error_doc = frappe.new_doc("eTIMS Sync Error Log")
+        error_doc.settings_name = settings_name
+        error_doc.entry_type = entry_type
+        error_doc.total_errors = len(errors)
+        error_doc.sync_date = frappe.utils.now_datetime()
+
+        error_details = []
+        for error in errors:
+            error_details.append(
+                {
+                    "document_number": error.get("document", "Unknown"),
+                    "etims_id": error.get("etims_id", "Unknown"),
+                    "error_message": str(error.get("error", "Unknown error"))[:1000],
+                    "error_traceback": error.get("traceback", "")[:2000],
+                    "error_type": error.get("type", entry_type),
+                }
+            )
+
+        error_doc.errors_json = frappe.as_json(error_details)
+        error_doc.insert(ignore_permissions=True)
+
+        frappe.db.commit()
+
+    except Exception as e:
+        frappe.log_error(
+            title="eTIMS Error Batch Save Failed",
+            message=f"Failed to save error batch: {str(e)}\nErrors: {frappe.as_json(errors)}",
+        )
+
+
 def process_single_etims_entry(
-    entry_data: dict, entry_type: str, settings_name: str
+    entry_data: dict, entry_type: str, settings_name: str, company: str = None
 ) -> None:
     slade_id = entry_data.get("id")
     if not slade_id:
@@ -772,6 +940,7 @@ def process_single_etims_entry(
 
     update_values = {
         "etims_settings": settings_name,
+        "company": company,
         "type": entry_type,
         "invoice_date": invoice_date,
         "reference_number": entry_data.get("reference_number"),
@@ -825,6 +994,7 @@ def process_single_etims_entry(
                 frappe.db.set_value(
                     "eTIMS Sales Ledger Entry", existing_name, field, value
                 )
+
         sales_ledger_name = existing_name
 
         existing_child_records = frappe.get_all(
@@ -840,7 +1010,13 @@ def process_single_etims_entry(
         for field, value in update_values.items():
             if value is not None:
                 setattr(sales_ledger, field, value)
-        sales_ledger.insert(ignore_permissions=True)
+
+        try:
+            sales_ledger.insert(ignore_permissions=True)
+        except frappe.UniqueValidationError:
+            frappe.db.rollback()
+            return
+
         sales_ledger_name = sales_ledger.name
 
     if is_cn:
@@ -923,54 +1099,3 @@ def process_single_etims_entry(
         )
         if sales_invoice:
             update_sales_invoice_etims_details(sales_invoice)
-
-
-def fetch_etims_sales_invoices_on_success(response: dict, **kwargs) -> None:
-    data = response.get("results")
-    if not data or not isinstance(data, list):
-        return
-
-    settings_name = kwargs.get("settings_name")
-    if not settings_name:
-        frappe.log_error(
-            title="eTIMS Fetch Error", message="Settings name not provided in kwargs"
-        )
-        return
-
-    for invoice_data in data:
-        try:
-            process_single_etims_entry(invoice_data, "Sales Invoice", settings_name)
-
-            credit_notes = invoice_data.get("credit_notes") or []
-            for cn_data in credit_notes:
-                process_single_etims_entry(cn_data, "Credit Note", settings_name)
-
-        except Exception as e:
-            doc_ref = invoice_data.get("document_number", "Unknown Document")
-            frappe.log_error(
-                title=f"eTIMS Sync Error - {doc_ref}",
-                message=f"Error: {str(e)}\nTraceback: {frappe.get_traceback()}",
-            )
-
-
-def fetch_etims_credit_notes_on_success(response: dict, **kwargs) -> None:
-    data = response.get("results")
-    if not data or not isinstance(data, list):
-        return
-
-    settings_name = kwargs.get("settings_name")
-    if not settings_name:
-        frappe.log_error(
-            title="eTIMS Fetch Error", message="Settings name not provided in kwargs"
-        )
-        return
-
-    for cn_data in data:
-        try:
-            process_single_etims_entry(cn_data, "Credit Note", settings_name)
-        except Exception as e:
-            doc_ref = cn_data.get("document_number", "Unknown Document")
-            frappe.log_error(
-                title=f"eTIMS Sync Error - {doc_ref}",
-                message=f"Error: {str(e)}\nTraceback: {frappe.get_traceback()}",
-            )

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/tasks.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/tasks.py
@@ -675,15 +675,37 @@ def fetch_etims_sales_data(
 ) -> None:
     request_data = parse_request_data(request_data)
 
-    if invoice_type in ("Sales Invoice", "Both"):
-        fetch_etims_sales_invoices(
-            request_data, settings_name, document_name=document_name
-        )
+    if document_name:
+        sales_invoice = frappe.get_doc("Sales Invoice", document_name)
+        company = sales_invoice.company
 
-    if invoice_type in ("Credit Note", "Both"):
-        fetch_etims_credit_notes(
-            request_data, settings_name, document_name=document_name
-        )
+        if invoice_type in ("Sales Invoice", "Both"):
+            fetch_etims_sales_invoices(
+                request_data,
+                settings_name,
+                document_name=document_name,
+                company=company,
+            )
+
+        if invoice_type in ("Credit Note", "Both"):
+            fetch_etims_credit_notes(
+                request_data,
+                settings_name,
+                document_name=document_name,
+                company=company,
+            )
+
+    else:
+        settings = frappe.get_doc(SETTINGS_DOCTYPE_NAME, settings_name)
+
+        for mapping in settings.organisation_mapping:
+            company = mapping.company
+
+            if invoice_type in ("Sales Invoice", "Both"):
+                fetch_etims_sales_invoices(request_data, settings_name, company=company)
+
+            if invoice_type in ("Credit Note", "Both"):
+                fetch_etims_credit_notes(request_data, settings_name, company=company)
 
 
 @frappe.whitelist()
@@ -691,6 +713,7 @@ def fetch_etims_sales_invoices(
     request_data: str | dict = None,
     settings_name: str = None,
     document_name: str = None,
+    company: str = None,
 ) -> None:
     request_data = parse_request_data(request_data)
 
@@ -705,6 +728,7 @@ def fetch_etims_sales_invoices(
         settings_name=settings_name,
         document_name=document_name,
         handler_function=fetch_etims_sales_invoices_on_success,
+        company=company,
     )
 
 
@@ -713,6 +737,7 @@ def fetch_etims_credit_notes(
     request_data: str | dict = None,
     settings_name: str = None,
     document_name: str = None,
+    company: str = None,
 ) -> None:
     # request_data = parse_request_data(request_data)
     request_data = {}
@@ -731,6 +756,7 @@ def fetch_etims_credit_notes(
         document_name=document_name,
         handler_function=fetch_etims_credit_notes_on_success,
         page_size=50,
+        company=company,
     )
 
 

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/navari_kra_etims_settings/navari_kra_etims_settings.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/navari_kra_etims_settings/navari_kra_etims_settings.js
@@ -87,7 +87,6 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
               });
             },
             error: (error) => {
-              // Error Handling is Defered to the Server
               frappe.msgprint({
                 title: __("Error"),
                 indicator: "red",
@@ -135,7 +134,6 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
                   });
                 },
                 error: (error) => {
-                  // Error Handling is Defered to the Server
                   frappe.msgprint({
                     title: __("Error"),
                     indicator: "red",
@@ -145,7 +143,6 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
               });
             },
             error: (error) => {
-              // Error Handling is Defered to the Server
               frappe.msgprint({
                 title: __("Error"),
                 indicator: "red",
@@ -285,7 +282,6 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
       },
       __("eTims Actions"),
     );
-
     frappe.call({
       method:
         "kenya_compliance_via_slade.kenya_compliance_via_slade.utils.check_hanging_custom_fields",
@@ -293,7 +289,84 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
         let fields = r.message || [];
         if (fields.length > 0) {
           frm.add_custom_button(
-            __("Clear Hanging Custom Fields"),
+            __("Run Data Migration"),
+            function () {
+              let d = new frappe.ui.Dialog({
+                title: __("Configure Data Migration Range"),
+                fields: [
+                  {
+                    label: __("Migrate Records From"),
+                    fieldname: "from_date",
+                    fieldtype: "Date",
+                    default: frappe.datetime.add_months(
+                      frappe.datetime.get_today(),
+                      -12,
+                    ),
+                    reqd: 1,
+                    description: __(
+                      "Historical cutoff boundary for heavy transaction tables (Sales Invoice, Stock Ledger, etc.).",
+                    ),
+                  },
+                ],
+                primary_action_label: __("Start Pipeline"),
+                primary_action: function (values) {
+                  d.hide();
+
+                  frappe.show_progress(
+                    __("Migrating Legacy eTims Data"),
+                    1,
+                    100,
+                    __("Initiating background job component..."),
+                  );
+
+                  frappe.call({
+                    method:
+                      "kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_csf_ke_data.migrate",
+                    args: {
+                      from_date: values.from_date,
+                    },
+                    callback: function (response) {
+                      frappe.show_alert({
+                        title: __("Pipeline Initialized"),
+                        indicator: "green",
+                        message: __(
+                          "Background worker dispatched. Reloading context...",
+                        ),
+                      });
+
+                      frappe.msgprint({
+                        title: __("Migration Job Started"),
+                        indicator: "blue",
+                        message: __(`
+                          The migration process is running asynchronously in the background.<br><br>
+                          <b>How to Cancel / Stop:</b><br>
+                          If you need to terminate this process, you can track and stop it directly via the 
+                          <a href="/app/rq-job?job_name=%5B%22like%22%2C%22%25kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_csf_ke_data.run_heavy_migrations%25%22%5D" target="_blank" rel="noopener noreferrer" style="text-decoration: underline; font-weight: bold;">
+                            Active RQ Migration Jobs
+                          </a> view by clicking <b>Force Stop Job</b> on the running task instance under the worker queue.
+                        `),
+                      });
+                    },
+                    error: function (error) {
+                      frappe.hide_progress();
+                      frappe.msgprint({
+                        title: __("Pipeline Error"),
+                        indicator: "red",
+                        message: __(
+                          "Failed to queue background worker process. Check error logs.",
+                        ),
+                      });
+                    },
+                  });
+                },
+              });
+              d.show();
+            },
+            __("CSF KE Migration"),
+          );
+
+          frm.add_custom_button(
+            __("Clear Hanging Fields"),
             function () {
               let field_list_html = fields
                 .map(
@@ -303,9 +376,13 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
                 .join("");
 
               frappe.confirm(
-                __(
-                  `Are you sure you want to delete the following hanging custom fields?<br><br><ul style="max-height: 200px; overflow-y: auto;">${field_list_html}</ul>`,
-                ),
+                __(`
+              <div class="alert alert-warning" style="margin-bottom: 15px;">
+                <strong>⚠️ Warning:</strong> Ensure you have successfully executed the <b>Run Data Migration</b> routine first. Dropping these custom fields before running migration will result in permanent loss of legacy eTims history.
+              </div>
+              Are you sure you want to delete the following hanging custom fields?<br><br>
+              <ul style="max-height: 200px; overflow-y: auto;">${field_list_html}</ul>
+            `),
                 function () {
                   frappe.call({
                     method:
@@ -320,8 +397,8 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
                           message: __(res.message.message),
                         });
                         frm.remove_custom_button(
-                          __("Clear Hanging Custom Fields"),
-                          __("eTims Actions"),
+                          __("Clear Hanging Fields"),
+                          __("CSF KE Migration"),
                         );
                       }
                     },
@@ -329,7 +406,7 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
                 },
               );
             },
-            __("eTims Actions"),
+            __("CSF KE Migration"),
           );
         }
       },

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/migrate_csf_ke_data.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/migrate_csf_ke_data.py
@@ -1,116 +1,415 @@
 import frappe
+from frappe.utils import add_years, today
 
-from ..utils import (
-    build_verification_url,
-)
+from ..utils import build_verification_url
 
 
 def execute():
-    migrate_etims_id_mapping()
+    pass
 
-    migrate_doctype_fields(
-        "Item",
-        {
-            "custom_prevent_etims_registration": "etims_prevent_etims_registration",
-            "custom_submission_tries": "etims_submission_tries",
-            "custom_taxation_type": "etims_taxation_type",
-            "custom_taxation_type_name": "etims_taxation_type_name",
-            "custom_item_classification": "etims_item_classification",
-            "custom_item_classification_code": "etims_item_classification_code",
-            "custom_etims_country_of_origin": "etims_country_of_origin",
-            "custom_etims_country_of_origin_code": "etims_country_of_origin_code",
-            "custom_packaging_unit": "etims_packaging_unit",
-            "custom_unit_of_quantity_code": "etims_unit_of_quantity_code",
-            "custom_unit_of_quantity": "etims_unit_of_quantity",
-            "custom_packaging_unit_code": "etims_packaging_unit_code",
-            "custom_item_type": "etims_item_type",
-            "custom_product_type": "etims_product_type",
-            "custom_item_type_name": "etims_item_type_name",
-            "custom_product_type_name": "etims_product_type_name",
-        },
-        "eTims Item Field Migration Failed",
+
+@frappe.whitelist()
+def migrate(from_date=None):
+    if not from_date:
+        from_date = add_years(today(), -1)
+
+    frappe.cache().set_value(
+        "etims_migration_progress",
+        {"percent": 1, "description": "Initializing Data Migration..."},
+    )
+    frappe.enqueue(
+        method="kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_csf_ke_data.run_heavy_migrations",
+        queue="long",
+        timeout=4000,
+        now=frappe.flags.in_test,
+        from_date=from_date,
     )
 
-    migrate_doctype_fields(
-        "Item Group",
-        {
-            "custom_prevent_etims_registration": "etims_prevent_etims_registration",
-            "custom_taxation_type": "etims_taxation_type",
-            "custom_taxation_type_name": "etims_taxation_type_name",
-            "custom_item_classification": "etims_item_classification",
-            "custom_item_classification_code": "etims_item_classification_code",
-            "custom_etims_country_of_origin": "etims_country_of_origin",
-            "custom_etims_country_of_origin_code": "etims_country_of_origin_code",
-            "custom_packaging_unit": "etims_packaging_unit",
-            "custom_unit_of_quantity_code": "etims_unit_of_quantity_code",
-            "custom_unit_of_quantity": "etims_unit_of_quantity",
-            "custom_packaging_unit_code": "etims_packaging_unit_code",
-            "custom_item_type": "etims_item_type",
-            "custom_product_type": "etims_product_type",
-            "custom_item_type_name": "etims_item_type_name",
-            "custom_product_type_name": "etims_product_type_name",
-        },
-        "eTims Item Group Field Migration Failed",
+
+@frappe.whitelist()
+def get_migration_status():
+    status = frappe.cache().get_value("etims_migration_progress")
+    if not status:
+        return {"percent": 0, "description": "No active migration found."}
+    return status
+
+
+def update_migration_progress(percent, description):
+    frappe.cache().set_value(
+        "etims_migration_progress", {"percent": percent, "description": description}
+    )
+    frappe.publish_progress(
+        percent,
+        title="Migrating Legacy eTims Data",
+        description=description,
     )
 
-    migrate_doctype_fields(
-        "Item Tax Template",
-        {
-            "custom_etims_taxation_type": "etims_taxation_type",
-        },
-        "eTims Item Tax Template Field Migration Failed",
-    )
 
-    migrate_doctype_fields(
-        "Sales Taxes and Charges Template",
-        {
-            "custom_etims_taxation_type": "etims_taxation_type",
-        },
-        "eTims Sales Taxes and Charges Template Field Migration Failed",
-    )
+def run_heavy_migrations(from_date):
+    try:
+        update_migration_progress(1, "Populating Master Child Table Mapping Records...")
+        migrate_master_child_tables(["Item", "Customer", "Supplier"])
 
-    # migrate_doctype_fields(
-    #     "Stock Ledger Entry",
-    #     {
-    #         "custom_submitted_successfully": "sent_to_etims",
-    #         "custom_submission_tries": "etims_submission_attempts",
-    #         "custom_slade_id": "etims_id",
-    #     },
-    #     "eTims Stock Ledger Entry Field Migration Failed",
-    # )
+        update_migration_progress(20, "Re-mapping Master Target ID Configurations...")
+        reconcile_master_id_mappings()
 
-    # migrate_doctype_fields(
-    #     "Sales Invoice",
-    #     {
-    #         "custom_successfully_submitted": "sent_to_etims",
-    #         "custom_slade_id": "etims_id",
-    #         "custom_qr_code_url": "etims_qr_code_url",
-    #         "custom_submission_attempts": "etims_submission_attempts",
-    #         "custom_qr_code": "etims_qr_image",
-    #     },
-    #     "eTims Sales Invoice Field Migration Failed",
-    # )
+        migrate_doctype_fields(
+            "Item",
+            {
+                "custom_prevent_etims_registration": "etims_prevent_etims_registration",
+                "custom_submission_tries": "etims_submission_tries",
+                "custom_taxation_type": "etims_taxation_type",
+                "custom_taxation_type_name": "etims_taxation_type_name",
+                "custom_item_classification": "etims_item_classification",
+                "custom_item_classification_code": "etims_item_classification_code",
+                "custom_etims_country_of_origin": "etims_country_of_origin",
+                "custom_etims_country_of_origin_code": "etims_country_of_origin_code",
+                "custom_packaging_unit": "etims_packaging_unit",
+                "custom_unit_of_quantity_code": "etims_unit_of_quantity_code",
+                "custom_unit_of_quantity": "etims_unit_of_quantity",
+                "custom_packaging_unit_code": "etims_packaging_unit_code",
+                "custom_item_type": "etims_item_type",
+                "custom_product_type": "etims_product_type",
+                "custom_item_type_name": "etims_item_type_name",
+                "custom_product_type_name": "etims_product_type_name",
+            },
+            "eTims Item Field Migration Failed",
+            start_perc=25,
+            end_perc=35,
+            main_criterion_field="custom_item_classification_code",
+        )
 
-    # migrate_doctype_fields(
-    #     "Sales Invoice Item",
-    #     {
-    #         "custom_tax_amount": "etims_tax_amount",
-    #         "custom_base_tax_amount": "etims_base_tax_amount",
-    #         "custom_tax_rate": "etims_tax_rate",
-    #     },
-    #     "eTims Sales Invoice Item Field Migration Failed",
-    # )
+        migrate_doctype_fields(
+            "Item Group",
+            {
+                "custom_prevent_etims_registration": "etims_prevent_etims_registration",
+                "custom_taxation_type": "etims_taxation_type",
+                "custom_taxation_type_name": "etims_taxation_type_name",
+                "custom_item_classification": "etims_item_classification",
+                "custom_item_classification_code": "etims_item_classification_code",
+                "custom_etims_country_of_origin": "etims_country_of_origin",
+                "custom_etims_country_of_origin_code": "etims_country_of_origin_code",
+                "custom_packaging_unit": "etims_packaging_unit",
+                "custom_unit_of_quantity_code": "etims_unit_of_quantity_code",
+                "custom_unit_of_quantity": "etims_unit_of_quantity",
+                "custom_packaging_unit_code": "etims_packaging_unit_code",
+                "custom_item_type": "etims_item_type",
+                "custom_product_type": "etims_product_type",
+                "custom_item_type_name": "etims_item_type_name",
+                "custom_product_type_name": "etims_product_type_name",
+            },
+            "eTims Item Group Field Migration Failed",
+            start_perc=35,
+            end_perc=45,
+            main_criterion_field="custom_item_classification_code",
+        )
 
-    migrate_doctype_fields(
-        "Customer",
-        {
-            "custom_prevent_etims_registration": "etims_prevent_etims_registration",
-        },
-        "eTims Customer Field Migration Failed",
-    )
+        update_migration_progress(46, "Processing Item Tax Templates...")
+        migrate_doctype_fields(
+            "Item Tax Template",
+            {
+                "custom_etims_taxation_type": "etims_taxation_type",
+            },
+            "eTims Item Tax Template Field Migration Failed",
+            start_perc=46,
+            end_perc=48,
+            main_criterion_field="custom_etims_taxation_type",
+        )
 
-    # generate_invoice_verification_urls()
-    set_etims_submission_modes()
+        update_migration_progress(49, "Processing Sales Taxes Templates...")
+        migrate_doctype_fields(
+            "Sales Taxes and Charges Template",
+            {
+                "custom_etims_taxation_type": "etims_taxation_type",
+            },
+            "eTims Sales Taxes and Charges Template Field Migration Failed",
+            start_perc=49,
+            end_perc=52,
+            main_criterion_field="custom_etims_taxation_type",
+        )
+
+        update_migration_progress(53, "Processing Customer Master Fields...")
+        migrate_doctype_fields(
+            "Customer",
+            {
+                "custom_prevent_etims_registration": "etims_prevent_etims_registration",
+            },
+            "eTims Customer Field Migration Failed",
+            start_perc=53,
+            end_perc=60,
+            main_criterion_field="custom_prevent_etims_registration",
+        )
+
+        migrate_doctype_fields_batched(
+            "Stock Ledger Entry",
+            {
+                "custom_submitted_successfully": "sent_to_etims",
+                "custom_submission_tries": "etims_submission_attempts",
+                "custom_slade_id": "etims_id",
+            },
+            "eTims Stock Ledger Entry Field Migration Failed",
+            60,
+            75,
+            from_date=from_date,
+            date_field="posting_date",
+            main_criterion_field="custom_slade_id",
+        )
+
+        migrate_doctype_fields_batched(
+            "Sales Invoice",
+            {
+                "custom_successfully_submitted": "sent_to_etims",
+                "custom_slade_id": "etims_id",
+                "custom_qr_code_url": "etims_qr_code_url",
+                "custom_submission_attempts": "etims_submission_attempts",
+                "custom_qr_code": "etims_qr_image",
+            },
+            "eTims Sales Invoice Field Migration Failed",
+            75,
+            90,
+            from_date=from_date,
+            date_field="posting_date",
+            main_criterion_field="custom_slade_id",
+        )
+
+        migrate_doctype_fields_batched(
+            "Sales Invoice Item",
+            {
+                "custom_tax_amount": "etims_tax_amount",
+                "custom_base_tax_amount": "etims_base_tax_amount",
+                "custom_tax_rate": "etims_tax_rate",
+            },
+            "eTims Sales Invoice Item Field Migration Failed",
+            90,
+            95,
+            from_date=from_date,
+            date_field="creation",
+            main_criterion_field="custom_tax_rate",
+        )
+
+        generate_invoice_verification_urls(from_date)
+
+        update_migration_progress(98, "Finishing up submission rules settings...")
+        set_etims_submission_modes()
+
+        update_migration_progress(100, "Migration successfully finished!")
+
+    except Exception:
+        frappe.db.rollback()
+        update_migration_progress(0, "Migration stopped due to errors.")
+
+
+def reconcile_master_id_mappings():
+    if not frappe.db.exists("DocType", "eTims ID Mapping"):
+        return
+
+    doctypes = ["Customer", "Item", "Supplier"]
+    for d_idx, doctype in enumerate(doctypes, start=1):
+        if not frappe.db.exists("DocType", doctype):
+            continue
+
+        records = frappe.get_all(doctype, fields=["name"], limit_page_length=0)
+        total_records = len(records)
+        if not total_records:
+            continue
+
+        for idx, row in enumerate(records, start=1):
+            if idx % 20 == 0 or idx == total_records:
+                current_perc = int(((d_idx - 1) / len(doctypes)) * 15) + 20
+                update_migration_progress(
+                    current_perc,
+                    f"Cross-referencing {doctype} configuration structures ({idx}/{total_records})...",
+                )
+
+            try:
+                doc = frappe.get_doc(doctype, row.name)
+                setup_mappings = doc.get("etims_setup_mapping") or []
+
+                existing_global_entries = frappe.get_all(
+                    "eTims ID Mapping",
+                    filters={"parent": doc.name, "parenttype": doctype},
+                    fields=["name", "etims_id", "disabled", "setup_docname"],
+                )
+
+                seen_pairs = set()
+                for entry in existing_global_entries:
+                    pair_key = (entry.setup_docname, entry.etims_id)
+                    if pair_key in seen_pairs:
+                        frappe.delete_doc(
+                            "eTims ID Mapping", entry.name, ignore_permissions=True
+                        )
+                        continue
+                    seen_pairs.add(pair_key)
+
+                existing_global_entries = frappe.get_all(
+                    "eTims ID Mapping",
+                    filters={"parent": doc.name, "parenttype": doctype},
+                    fields=["name", "etims_id", "disabled", "setup_docname"],
+                )
+
+                if not setup_mappings:
+                    for entry in existing_global_entries:
+                        if not entry.disabled:
+                            frappe.db.set_value(
+                                "eTims ID Mapping",
+                                entry.name,
+                                "disabled",
+                                1,
+                                update_modified=False,
+                            )
+                    continue
+
+                for child in setup_mappings:
+                    child_setup = getattr(child, "etims_setup", None) or getattr(
+                        child, "setup_docname", None
+                    )
+                    child_id = getattr(child, "etims_id", None) or getattr(
+                        child, "custom_slade_id", None
+                    )
+                    child_active = not getattr(child, "disabled", 0) and getattr(
+                        child, "registered", 1
+                    )
+
+                    if not child_setup or not child_id:
+                        continue
+
+                    match_found = False
+                    for entry in existing_global_entries:
+                        if (
+                            entry.setup_docname == child_setup
+                            and entry.etims_id == child_id
+                        ):
+                            match_found = True
+                            target_disabled = 0 if child_active else 1
+                            if entry.disabled != target_disabled:
+                                frappe.db.set_value(
+                                    "eTims ID Mapping",
+                                    entry.name,
+                                    "disabled",
+                                    target_disabled,
+                                    update_modified=False,
+                                )
+                            break
+
+                    if not match_found:
+                        new_mapping = frappe.get_doc(
+                            {
+                                "doctype": "eTims ID Mapping",
+                                "setup_doctype": "Navari KRA eTims Settings",
+                                "setup_docname": child_setup,
+                                "etims_id": child_id,
+                                "disabled": 0 if child_active else 1,
+                                "parent": doc.name,
+                                "parenttype": doctype,
+                                "parentfield": "etims_id_mapping",
+                            }
+                        )
+                        new_mapping.insert(ignore_permissions=True)
+
+                for entry in existing_global_entries:
+                    child_match = False
+                    for child in setup_mappings:
+                        child_setup = getattr(child, "etims_setup", None) or getattr(
+                            child, "setup_docname", None
+                        )
+                        child_id = getattr(child, "etims_id", None) or getattr(
+                            child, "custom_slade_id", None
+                        )
+                        if (
+                            child_setup == entry.setup_docname
+                            and child_id == entry.etims_id
+                        ):
+                            child_match = True
+                            break
+
+                    if not child_match and not entry.disabled:
+                        frappe.db.set_value(
+                            "eTims ID Mapping",
+                            entry.name,
+                            "disabled",
+                            1,
+                            update_modified=False,
+                        )
+
+                if idx % 100 == 0:
+                    frappe.db.commit()
+
+            except Exception:
+                frappe.db.rollback()
+                frappe.log_error(
+                    title=f"Mapping Synchronization Broken for {doctype} {row.name}",
+                    message=frappe.get_traceback(),
+                )
+                frappe.db.commit()
+
+        frappe.db.commit()
+
+
+def migrate_master_child_tables(doctypes):
+    for d_idx, doctype in enumerate(doctypes, start=1):
+        if not frappe.db.exists("DocType", doctype):
+            continue
+
+        meta = frappe.get_meta(doctype)
+        if not meta.has_field("etims_setup_mapping"):
+            continue
+
+        records = frappe.get_all(
+            doctype,
+            filters={"custom_item_classification_code": ("is", "set")}
+            if doctype == "Item"
+            else {},
+            fields=["name"],
+            limit_page_length=0,
+        )
+        total_records = len(records)
+        if not total_records:
+            continue
+
+        for idx, row in enumerate(records, start=1):
+            if idx % 10 == 0 or idx == total_records:
+                current_perc = int(((d_idx - 1) / len(doctypes)) * 15) + 1
+                update_migration_progress(
+                    current_perc,
+                    f"Mapping {doctype} setups ({idx}/{total_records})...",
+                )
+
+            try:
+                doc = frappe.get_doc(doctype, row.name)
+                has_changes = False
+
+                for child in doc.get("etims_setup_mapping"):
+                    if (
+                        hasattr(child, "custom_slade_id")
+                        and child.custom_slade_id
+                        and not child.etims_id
+                    ):
+                        child.etims_id = child.custom_slade_id
+                        has_changes = True
+
+                    if (
+                        hasattr(child, "custom_submitted_successfully")
+                        and child.custom_submitted_successfully
+                        and not child.registered
+                    ):
+                        child.registered = child.custom_submitted_successfully
+                        has_changes = True
+
+                if has_changes:
+                    doc.save(ignore_permissions=True, ignore_version=True)
+
+                if idx % 100 == 0:
+                    frappe.db.commit()
+
+            except Exception:
+                frappe.db.rollback()
+                frappe.log_error(
+                    title=f"eTims Setup Mapping Child Table Migration Failed for {doctype}",
+                    message=frappe.get_traceback(),
+                )
+                frappe.db.commit()
+
+        frappe.db.commit()
 
 
 def get_valid_field_map(doctype, field_map):
@@ -124,21 +423,110 @@ def get_valid_field_map(doctype, field_map):
     return valid_map
 
 
-def migrate_doctype_fields(doctype, field_map, error_title):
+def migrate_doctype_fields(
+    doctype, field_map, error_title, start_perc, end_perc, main_criterion_field=None
+):
     valid_field_map = get_valid_field_map(doctype, field_map)
     if not valid_field_map:
         return
 
+    filters = {}
+    if main_criterion_field and frappe.db.has_column(doctype, main_criterion_field):
+        filters[main_criterion_field] = ("is", "set")
+
     records = frappe.get_all(
         doctype,
+        filters=filters,
         fields=["name"] + list(valid_field_map.keys()),
         limit_page_length=0,
     )
+    total_records = len(records)
+    if not total_records:
+        return
+
+    perc_range = end_perc - start_perc
 
     for idx, record in enumerate(records, start=1):
+        if idx % 25 == 0 or idx == total_records:
+            progress_perc = start_perc + int((idx / total_records) * perc_range)
+            update_migration_progress(
+                progress_perc,
+                f"Processing {doctype} metadata registers ({idx}/{total_records})...",
+            )
+
         try:
             update_values = {}
+            for src, target in valid_field_map.items():
+                value = getattr(record, src, None)
+                if value is not None:
+                    update_values[target] = value
 
+            if not update_values:
+                continue
+
+            frappe.db.set_value(
+                doctype,
+                record.name,
+                update_values,
+                update_modified=False,
+            )
+
+            if idx % 500 == 0:
+                frappe.db.commit()
+
+        except Exception:
+            frappe.db.rollback()
+            frappe.log_error(
+                title=error_title,
+                message=frappe.get_traceback(),
+            )
+            frappe.db.commit()
+
+    frappe.db.commit()
+
+
+def migrate_doctype_fields_batched(
+    doctype,
+    field_map,
+    error_title,
+    start_perc,
+    end_perc,
+    from_date=None,
+    date_field="posting_date",
+    main_criterion_field=None,
+):
+    valid_field_map = get_valid_field_map(doctype, field_map)
+    if not valid_field_map:
+        return
+
+    filters = {}
+    if from_date and frappe.db.has_column(doctype, date_field):
+        filters[date_field] = (">=", from_date)
+    if main_criterion_field and frappe.db.has_column(doctype, main_criterion_field):
+        filters[main_criterion_field] = ("is", "set")
+
+    records = frappe.get_all(
+        doctype,
+        filters=filters,
+        fields=["name"] + list(valid_field_map.keys()),
+        limit_page_length=0,
+    )
+    total_records = len(records)
+    if not total_records:
+        return
+
+    perc_range = end_perc - start_perc
+
+    for idx, record in enumerate(records, start=1):
+        if idx % 50 == 0 or idx == total_records:
+            progress_perc = start_perc + int((idx / total_records) * perc_range)
+            update_migration_progress(
+                progress_perc,
+                f"Updating {doctype} rows ({idx}/{total_records})...",
+            )
+
+        try:
+            update_values = {}
             for src, target in valid_field_map.items():
                 value = getattr(record, src, None)
                 if value is not None:
@@ -168,77 +556,33 @@ def migrate_doctype_fields(doctype, field_map, error_title):
     frappe.db.commit()
 
 
-def migrate_etims_id_mapping():
-    if not frappe.db.exists(
-        "DocType", "eTims Slade360 ID Mapping"
-    ) or not frappe.db.exists("DocType", "eTims ID Mapping"):
-        return
+def generate_invoice_verification_urls(from_date=None):
+    filters = {
+        "docstatus": 1,
+        "etims_verification_url": ("is", None),
+        "etims_id": ("is", "set"),
+    }
+    if from_date:
+        filters["posting_date"] = (">=", from_date)
 
-    old_rows = frappe.get_all(
-        "eTims Slade360 ID Mapping",
-        fields=[
-            "name",
-            "parent",
-            "parenttype",
-            "etims_setup",
-            "slade360_id",
-            "is_active",
-        ],
-        limit_page_length=0,
-    )
-
-    for idx, row in enumerate(old_rows, start=1):
-        try:
-            exists = frappe.db.exists(
-                "eTims ID Mapping",
-                {
-                    "setup_doctype": "Navari KRA eTims Settings",
-                    "setup_docname": row.etims_setup,
-                    "etims_id": row.slade360_id,
-                },
-            )
-
-            if exists:
-                continue
-
-            doc = frappe.get_doc(
-                {
-                    "doctype": "eTims ID Mapping",
-                    "setup_doctype": "Navari KRA eTims Settings",
-                    "setup_docname": row.etims_setup,
-                    "etims_id": row.slade360_id,
-                    "disabled": 0 if row.is_active else 1,
-                    "parent": row.parent,
-                    "parenttype": row.parenttype,
-                    "parentfield": "etims_id_mapping",
-                }
-            )
-
-            doc.insert(ignore_permissions=True)
-
-            if idx % 1000 == 0:
-                frappe.db.commit()
-
-        except Exception:
-            frappe.db.rollback()
-            frappe.log_error(
-                title="eTims ID Mapping Migration Failed",
-                message=frappe.get_traceback(),
-            )
-            frappe.db.commit()
-
-    frappe.db.commit()
-
-
-def generate_invoice_verification_urls():
     invoices = frappe.get_all(
         "Sales Invoice",
-        filters={"docstatus": 1, "etims_verification_url": ("is", None)},
+        filters=filters,
         fields=["name"],
         limit_page_length=0,
     )
+    total_records = len(invoices)
+    if not total_records:
+        return
 
     for idx, invoice in enumerate(invoices, start=1):
+        if idx % 50 == 0 or idx == total_records:
+            progress_perc = 95 + int((idx / total_records) * 3)
+            update_migration_progress(
+                progress_perc,
+                f"Compiling verification URLs ({idx}/{total_records})...",
+            )
+
         try:
             doc = frappe.get_doc("Sales Invoice", invoice.name)
             url = build_verification_url(doc)
@@ -251,7 +595,7 @@ def generate_invoice_verification_urls():
                     update_modified=False,
                 )
 
-            if idx % 1000 == 0:
+            if idx % 500 == 0:
                 frappe.db.commit()
 
         except Exception:

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/migrate_csf_ke_data.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/migrate_csf_ke_data.py
@@ -48,7 +48,6 @@ def update_migration_progress(percent, description):
 def run_heavy_migrations(from_date):
     try:
         update_migration_progress(1, "Populating Master Child Table Mapping Records...")
-        migrate_master_child_tables(["Item", "Customer", "Supplier"])
 
         update_migration_progress(20, "Re-mapping Master Target ID Configurations...")
         reconcile_master_id_mappings()
@@ -260,15 +259,11 @@ def reconcile_master_id_mappings():
                     continue
 
                 for child in setup_mappings:
-                    child_setup = getattr(child, "etims_setup", None) or getattr(
-                        child, "setup_docname", None
+                    child_setup = getattr(child, "etims_setup", None)
+                    child_id = getattr(child, "slade360_id", None) or getattr(
+                        child, "etims_id", None
                     )
-                    child_id = getattr(child, "etims_id", None) or getattr(
-                        child, "custom_slade_id", None
-                    )
-                    child_active = not getattr(child, "disabled", 0) and getattr(
-                        child, "registered", 1
-                    )
+                    child_active = getattr(child, "is_active", 1)
 
                     if not child_setup or not child_id:
                         continue
@@ -309,11 +304,9 @@ def reconcile_master_id_mappings():
                 for entry in existing_global_entries:
                     child_match = False
                     for child in setup_mappings:
-                        child_setup = getattr(child, "etims_setup", None) or getattr(
-                            child, "setup_docname", None
-                        )
-                        child_id = getattr(child, "etims_id", None) or getattr(
-                            child, "custom_slade_id", None
+                        child_setup = getattr(child, "etims_setup", None)
+                        child_id = getattr(child, "slade360_id", None) or getattr(
+                            child, "etims_id", None
                         )
                         if (
                             child_setup == entry.setup_docname
@@ -338,73 +331,6 @@ def reconcile_master_id_mappings():
                 frappe.db.rollback()
                 frappe.log_error(
                     title=f"Mapping Synchronization Broken for {doctype} {row.name}",
-                    message=frappe.get_traceback(),
-                )
-                frappe.db.commit()
-
-        frappe.db.commit()
-
-
-def migrate_master_child_tables(doctypes):
-    for d_idx, doctype in enumerate(doctypes, start=1):
-        if not frappe.db.exists("DocType", doctype):
-            continue
-
-        meta = frappe.get_meta(doctype)
-        if not meta.has_field("etims_setup_mapping"):
-            continue
-
-        records = frappe.get_all(
-            doctype,
-            filters={"custom_item_classification_code": ("is", "set")}
-            if doctype == "Item"
-            else {},
-            fields=["name"],
-            limit_page_length=0,
-        )
-        total_records = len(records)
-        if not total_records:
-            continue
-
-        for idx, row in enumerate(records, start=1):
-            if idx % 10 == 0 or idx == total_records:
-                current_perc = int(((d_idx - 1) / len(doctypes)) * 15) + 1
-                update_migration_progress(
-                    current_perc,
-                    f"Mapping {doctype} setups ({idx}/{total_records})...",
-                )
-
-            try:
-                doc = frappe.get_doc(doctype, row.name)
-                has_changes = False
-
-                for child in doc.get("etims_setup_mapping"):
-                    if (
-                        hasattr(child, "custom_slade_id")
-                        and child.custom_slade_id
-                        and not child.etims_id
-                    ):
-                        child.etims_id = child.custom_slade_id
-                        has_changes = True
-
-                    if (
-                        hasattr(child, "custom_submitted_successfully")
-                        and child.custom_submitted_successfully
-                        and not child.registered
-                    ):
-                        child.registered = child.custom_submitted_successfully
-                        has_changes = True
-
-                if has_changes:
-                    doc.save(ignore_permissions=True, ignore_version=True)
-
-                if idx % 100 == 0:
-                    frappe.db.commit()
-
-            except Exception:
-                frappe.db.rollback()
-                frappe.log_error(
-                    title=f"eTims Setup Mapping Child Table Migration Failed for {doctype}",
                     message=frappe.get_traceback(),
                 )
                 frappe.db.commit()
@@ -559,7 +485,6 @@ def migrate_doctype_fields_batched(
 def generate_invoice_verification_urls(from_date=None):
     filters = {
         "docstatus": 1,
-        "etims_verification_url": ("is", None),
         "etims_id": ("is", "set"),
     }
     if from_date:

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -2423,7 +2423,7 @@ def check_hanging_custom_fields():
     hanging_fields = frappe.get_all(
         "Custom Field",
         filters={
-            "dt": ["in", doctypes],
+            # "dt": ["in", doctypes],
             "module": "Kenya Compliance Via Slade",
         },
         fields=["name", "dt", "fieldname", "label"],

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -2402,8 +2402,18 @@ def build_verification_url(doc) -> str:
     creation = get_datetime(doc.creation) if doc.creation else None
 
     key = creation.strftime("%Y%m%d%H%M%S%f") if creation else ""
+    base_url = frappe.utils.get_url()
 
-    return f"/invoice-verification?id={quote(str(doc.name))}&key={quote(key)}"
+    parsed_url = urlparse(base_url)
+
+    if parsed_url.hostname:
+        if not (
+            parsed_url.hostname == "localhost"
+            or parsed_url.hostname.replace(".", "").isdigit()
+        ):
+            base_url = f"{parsed_url.scheme}://{parsed_url.hostname}"
+
+    return f"{base_url}/invoice-verification?id={quote(str(doc.name))}&key={quote(key)}"
 
 
 @frappe.whitelist()

--- a/kenya_compliance_via_slade/patches.txt
+++ b/kenya_compliance_via_slade/patches.txt
@@ -6,5 +6,5 @@ kenya_compliance_via_slade.kenya_compliance_via_slade.patches.drop_custom_fields
 kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_to_multi_company # 153/07/25 
 kenya_compliance_via_slade.kenya_compliance_via_slade.patches.set_etims_mappings_active # 13/03/26
 kenya_compliance_via_slade.kenya_compliance_via_slade.patches.set_taxation_type_codes # 22/03/26
-kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_csf_ke_data # 13/06/2026
+# kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_csf_ke_data # 13/06/2026
 kenya_compliance_via_slade.kenya_compliance_via_slade.patches.purge_invalid_etims_ledger_records # 03/06/2026


### PR DESCRIPTION
This pull request introduces significant improvements to how company context is handled and passed throughout the eTIMS compliance workflow. The changes ensure that the `company` information is consistently propagated from API calls and background tasks down to database updates and error handling. Additionally, error logging and duplicate detection for eTIMS data synchronization have been enhanced for better reliability and traceability.

**Company context propagation and API enhancements:**

* Added a `company` property to the `ApiBuilder` class and ensured it is settable and gettable, allowing company information to be associated with API requests. The `company` parameter is now passed through all relevant API, remote call, and handler layers, including `make_remote_call`, `_handle_success`, and `_handle_error`, as well as through the request processing functions (`process_request`, `execute_remote_request`) and background tasks (`fetch_etims_sales_invoices`, `fetch_etims_credit_notes`). [[1]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R37) [[2]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R75-R83) [[3]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R347-R355) [[4]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R585) [[5]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R598) [[6]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R613) [[7]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R653) [[8]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R669) [[9]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R714) [[10]](diffhunk://#diff-8c4e4fc3316f9052a6b6ad198dd9e74a368ba204505e0bd75c7ec068234e7237R122) [[11]](diffhunk://#diff-8c4e4fc3316f9052a6b6ad198dd9e74a368ba204505e0bd75c7ec068234e7237R185) [[12]](diffhunk://#diff-8c4e4fc3316f9052a6b6ad198dd9e74a368ba204505e0bd75c7ec068234e7237R222) [[13]](diffhunk://#diff-07fa816e70125704befdf104e9a2dc83383e393842f04b759ae1ad8ea85f4633R322) [[14]](diffhunk://#diff-323951094c926ff6a103f94551ce30619827d31f420fd4801029d928b5319bcaR678-R716) [[15]](diffhunk://#diff-323951094c926ff6a103f94551ce30619827d31f420fd4801029d928b5319bcaR731) [[16]](diffhunk://#diff-323951094c926ff6a103f94551ce30619827d31f420fd4801029d928b5319bcaR740) [[17]](diffhunk://#diff-323951094c926ff6a103f94551ce30619827d31f420fd4801029d928b5319bcaR759)

**eTIMS data synchronization and error handling:**

* Refactored and improved the eTIMS sales invoices and credit notes synchronization handlers to:
  - Accept and utilize the `company` parameter.
  - Detect and log duplicate records within the same batch.
  - Collect and batch-save sync errors to a new `eTIMS Sync Error Log` document, including detailed error information and tracebacks. [[1]](diffhunk://#diff-3840b8bb1c5ee6a50168c1eb22d27b1d0bed84a1182135130f5f0b1300cbf9f9R741-R910) [[2]](diffhunk://#diff-3840b8bb1c5ee6a50168c1eb22d27b1d0bed84a1182135130f5f0b1300cbf9f9R943)
* Updated the `process_single_etims_entry` function to accept the `company` parameter, set it on ledger entries, and handle unique validation errors gracefully by rolling back on duplicates. [[1]](diffhunk://#diff-3840b8bb1c5ee6a50168c1eb22d27b1d0bed84a1182135130f5f0b1300cbf9f9R943) [[2]](diffhunk://#diff-3840b8bb1c5ee6a50168c1eb22d27b1d0bed84a1182135130f5f0b1300cbf9f9R997) [[3]](diffhunk://#diff-3840b8bb1c5ee6a50168c1eb22d27b1d0bed84a1182135130f5f0b1300cbf9f9R1013-R1019)

**Code cleanup and reliability:**

* Removed old versions of the eTIMS fetch handlers that did not support the new error batching and company context propagation.
* Minor cleanup in client-side JavaScript to remove outdated comments about error handling, reflecting that error handling is now robustly managed on the server side. [[1]](diffhunk://#diff-767ea2f3c4805c5aee77a3820f1ecd7a679c64ee3ba264c25d23f59a7a5dd70bL90) [[2]](diffhunk://#diff-767ea2f3c4805c5aee77a3820f1ecd7a679c64ee3ba264c25d23f59a7a5dd70bL138)