### PR TITLE
refactor: update eTIMS UI and backend for data migration and reconciliation

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/api_builder.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/api_builder.py
@@ -34,6 +34,7 @@ class BaseEndpointsBuilder:
         self._observers: list[ErrorObserver] = []
         self._doctype: str | Document | None = None
         self._document_name: str | None = None
+        self._company: str | None = None
 
     @property
     def integration_request(self) -> str | Document | None:
@@ -70,6 +71,15 @@ class BaseEndpointsBuilder:
     @document_name.setter
     def document_name(self, value: str | None) -> None:
         self._document_name = value
+
+    @property
+    def company(self) -> str | None:
+        """Company associated with the current request."""
+        return self._company
+
+    @company.setter
+    def company(self, value: str | None) -> None:
+        self._company = value
 
     def attach(self, observer: "ErrorObserver") -> None:
         """
@@ -334,6 +344,7 @@ class EndpointsBuilder(BaseEndpointsBuilder):
                     response_data,
                     self.doctype,
                     self.document_name,
+                    self.company,
                 )
             else:
                 self._handle_error(
@@ -341,6 +352,7 @@ class EndpointsBuilder(BaseEndpointsBuilder):
                     response_data,
                     self.doctype,
                     self.document_name,
+                    self.company,
                 )
 
                 if response.status_code == 401 and not retrying:
@@ -570,6 +582,7 @@ class EndpointsBuilder(BaseEndpointsBuilder):
         response_data: dict | str | bytes | None,
         doctype: str | None,
         document_name: str | None,
+        company: str | None = None,
     ) -> None:
         """
         Handle a 200/201 response.
@@ -582,6 +595,7 @@ class EndpointsBuilder(BaseEndpointsBuilder):
             response_data: Parsed response body.
             doctype: Reference doctype.
             document_name: Reference document name.
+            company: Company associated with the request.
         """
         frappe.db.set_value(
             "Integration Request",
@@ -596,6 +610,7 @@ class EndpointsBuilder(BaseEndpointsBuilder):
             doctype=doctype,
             payload=self.payload,
             settings_name=self.settings.name,
+            company=company,
         )
 
         current_page = (
@@ -635,6 +650,7 @@ class EndpointsBuilder(BaseEndpointsBuilder):
         response_data: dict | str | bytes | None,
         doctype: str | None,
         document_name: str | None,
+        company: str | None = None,
     ) -> None:
         """
         Handle a non-2xx response.
@@ -650,6 +666,7 @@ class EndpointsBuilder(BaseEndpointsBuilder):
             response_data: Parsed response body.
             doctype: Reference doctype.
             document_name: Reference document name.
+            company: Company associated with the request.
         """
         parsed_url = parse.urlparse(self.url)
 
@@ -694,6 +711,7 @@ class EndpointsBuilder(BaseEndpointsBuilder):
                 document_name=document_name,
                 payload=self.payload,
                 settings_name=self.settings.name,
+                company=company,
             )
 
 

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/process_request.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/process_request.py
@@ -119,6 +119,7 @@ def process_request(
                     job_queue=None,
                     page_size=page_size,
                     page=page,
+                    company=company_name,
                 )
 
     except Exception:
@@ -181,6 +182,7 @@ def execute_remote_request(
     job_queue: Document | None,
     page_size: int = 1000,
     page: int = 1,
+    company: str = None,
 ) -> None:
     """
     Configure ``EndpointsBuilder`` and issue the remote HTTP call.
@@ -217,6 +219,7 @@ def execute_remote_request(
     endpoints_builder.document_name = document_name
     endpoints_builder.page_size = page_size
     endpoints_builder.page = page
+    endpoints_builder.company = company
 
     response = endpoints_builder.make_remote_call()
 

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
@@ -319,6 +319,7 @@ def sales_information_submission_on_success(
         "kenya_compliance_via_slade.kenya_compliance_via_slade.background_tasks.tasks.fetch_etims_sales_invoices",
         document_name=document_name,
         settings_name=settings_name,
+        company=frappe.get_value(doctype, document_name, "company"),
         request_data={"reference_number": document_name},
         queue="long",
     )

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/task_response_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/task_response_handlers.py
@@ -738,8 +738,176 @@ def update_clusters(response: dict, settings_name: str, **kwargs) -> None:
     # })
 
 
+def fetch_etims_sales_invoices_on_success(
+    response: dict, company: str, **kwargs
+) -> None:
+    data = response.get("results")
+    if not data or not isinstance(data, list):
+        return
+
+    settings_name = kwargs.get("settings_name")
+    if not settings_name:
+        frappe.log_error(
+            title="eTIMS Fetch Error", message="Settings name not provided in kwargs"
+        )
+        return
+
+    errors = []
+    processed_ids = set()
+
+    for invoice_data in data:
+        try:
+            slade_id = invoice_data.get("id")
+            if slade_id in processed_ids:
+                errors.append(
+                    {
+                        "document": invoice_data.get(
+                            "document_number", "Unknown Document"
+                        ),
+                        "etims_id": slade_id,
+                        "error": "Duplicate record in same batch",
+                        "type": "Sales Invoice",
+                    }
+                )
+                continue
+
+            process_single_etims_entry(
+                invoice_data, "Sales Invoice", settings_name, company=company
+            )
+            processed_ids.add(slade_id)
+
+            credit_notes = invoice_data.get("credit_notes") or []
+            for cn_data in credit_notes:
+                cn_slade_id = cn_data.get("id")
+                if cn_slade_id in processed_ids:
+                    errors.append(
+                        {
+                            "document": cn_data.get(
+                                "document_number", "Unknown Document"
+                            ),
+                            "etims_id": cn_slade_id,
+                            "error": "Duplicate record in same batch",
+                            "type": "Credit Note",
+                        }
+                    )
+                    continue
+
+                process_single_etims_entry(
+                    cn_data, "Credit Note", settings_name, company=company
+                )
+                processed_ids.add(cn_slade_id)
+
+        except Exception as e:
+            doc_ref = invoice_data.get("document_number", "Unknown Document")
+            error_detail = {
+                "document": doc_ref,
+                "etims_id": invoice_data.get("id"),
+                "error": str(e),
+                "traceback": frappe.get_traceback(),
+                "type": "Sales Invoice",
+            }
+            errors.append(error_detail)
+
+            frappe.log_error(
+                title=f"eTIMS Sync Error - {doc_ref}",
+                message=f"Error: {str(e)}\nTraceback: {frappe.get_traceback()}",
+            )
+
+    if errors:
+        save_etims_sync_errors(errors, "Sales Invoice", settings_name)
+
+
+def fetch_etims_credit_notes_on_success(response: dict, company: str, **kwargs) -> None:
+    data = response.get("results")
+    if not data or not isinstance(data, list):
+        return
+
+    settings_name = kwargs.get("settings_name")
+    if not settings_name:
+        frappe.log_error(
+            title="eTIMS Fetch Error", message="Settings name not provided in kwargs"
+        )
+        return
+
+    errors = []
+    processed_ids = set()
+
+    for cn_data in data:
+        try:
+            slade_id = cn_data.get("id")
+            if slade_id in processed_ids:
+                errors.append(
+                    {
+                        "document": cn_data.get("document_number", "Unknown Document"),
+                        "etims_id": slade_id,
+                        "error": "Duplicate record in same batch",
+                        "type": "Credit Note",
+                    }
+                )
+                continue
+
+            process_single_etims_entry(
+                cn_data, "Credit Note", settings_name, company=company
+            )
+            processed_ids.add(slade_id)
+
+        except Exception as e:
+            doc_ref = cn_data.get("document_number", "Unknown Document")
+            error_detail = {
+                "document": doc_ref,
+                "etims_id": cn_data.get("id"),
+                "error": str(e),
+                "traceback": frappe.get_traceback(),
+                "type": "Credit Note",
+            }
+            errors.append(error_detail)
+
+            frappe.log_error(
+                title=f"eTIMS Sync Error - {doc_ref}",
+                message=f"Error: {str(e)}\nTraceback: {frappe.get_traceback()}",
+            )
+
+    if errors:
+        save_etims_sync_errors(errors, "Credit Note", settings_name)
+
+
+def save_etims_sync_errors(errors: list, entry_type: str, settings_name: str) -> None:
+    if not errors:
+        return
+
+    try:
+        error_doc = frappe.new_doc("eTIMS Sync Error Log")
+        error_doc.settings_name = settings_name
+        error_doc.entry_type = entry_type
+        error_doc.total_errors = len(errors)
+        error_doc.sync_date = frappe.utils.now_datetime()
+
+        error_details = []
+        for error in errors:
+            error_details.append(
+                {
+                    "document_number": error.get("document", "Unknown"),
+                    "etims_id": error.get("etims_id", "Unknown"),
+                    "error_message": str(error.get("error", "Unknown error"))[:1000],
+                    "error_traceback": error.get("traceback", "")[:2000],
+                    "error_type": error.get("type", entry_type),
+                }
+            )
+
+        error_doc.errors_json = frappe.as_json(error_details)
+        error_doc.insert(ignore_permissions=True)
+
+        frappe.db.commit()
+
+    except Exception as e:
+        frappe.log_error(
+            title="eTIMS Error Batch Save Failed",
+            message=f"Failed to save error batch: {str(e)}\nErrors: {frappe.as_json(errors)}",
+        )
+
+
 def process_single_etims_entry(
-    entry_data: dict, entry_type: str, settings_name: str
+    entry_data: dict, entry_type: str, settings_name: str, company: str = None
 ) -> None:
     slade_id = entry_data.get("id")
     if not slade_id:
@@ -772,6 +940,7 @@ def process_single_etims_entry(
 
     update_values = {
         "etims_settings": settings_name,
+        "company": company,
         "type": entry_type,
         "invoice_date": invoice_date,
         "reference_number": entry_data.get("reference_number"),
@@ -825,6 +994,7 @@ def process_single_etims_entry(
                 frappe.db.set_value(
                     "eTIMS Sales Ledger Entry", existing_name, field, value
                 )
+
         sales_ledger_name = existing_name
 
         existing_child_records = frappe.get_all(
@@ -840,7 +1010,13 @@ def process_single_etims_entry(
         for field, value in update_values.items():
             if value is not None:
                 setattr(sales_ledger, field, value)
-        sales_ledger.insert(ignore_permissions=True)
+
+        try:
+            sales_ledger.insert(ignore_permissions=True)
+        except frappe.UniqueValidationError:
+            frappe.db.rollback()
+            return
+
         sales_ledger_name = sales_ledger.name
 
     if is_cn:
@@ -923,54 +1099,3 @@ def process_single_etims_entry(
         )
         if sales_invoice:
             update_sales_invoice_etims_details(sales_invoice)
-
-
-def fetch_etims_sales_invoices_on_success(response: dict, **kwargs) -> None:
-    data = response.get("results")
-    if not data or not isinstance(data, list):
-        return
-
-    settings_name = kwargs.get("settings_name")
-    if not settings_name:
-        frappe.log_error(
-            title="eTIMS Fetch Error", message="Settings name not provided in kwargs"
-        )
-        return
-
-    for invoice_data in data:
-        try:
-            process_single_etims_entry(invoice_data, "Sales Invoice", settings_name)
-
-            credit_notes = invoice_data.get("credit_notes") or []
-            for cn_data in credit_notes:
-                process_single_etims_entry(cn_data, "Credit Note", settings_name)
-
-        except Exception as e:
-            doc_ref = invoice_data.get("document_number", "Unknown Document")
-            frappe.log_error(
-                title=f"eTIMS Sync Error - {doc_ref}",
-                message=f"Error: {str(e)}\nTraceback: {frappe.get_traceback()}",
-            )
-
-
-def fetch_etims_credit_notes_on_success(response: dict, **kwargs) -> None:
-    data = response.get("results")
-    if not data or not isinstance(data, list):
-        return
-
-    settings_name = kwargs.get("settings_name")
-    if not settings_name:
-        frappe.log_error(
-            title="eTIMS Fetch Error", message="Settings name not provided in kwargs"
-        )
-        return
-
-    for cn_data in data:
-        try:
-            process_single_etims_entry(cn_data, "Credit Note", settings_name)
-        except Exception as e:
-            doc_ref = cn_data.get("document_number", "Unknown Document")
-            frappe.log_error(
-                title=f"eTIMS Sync Error - {doc_ref}",
-                message=f"Error: {str(e)}\nTraceback: {frappe.get_traceback()}",
-            )

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/tasks.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/tasks.py
@@ -675,15 +675,37 @@ def fetch_etims_sales_data(
 ) -> None:
     request_data = parse_request_data(request_data)
 
-    if invoice_type in ("Sales Invoice", "Both"):
-        fetch_etims_sales_invoices(
-            request_data, settings_name, document_name=document_name
-        )
+    if document_name:
+        sales_invoice = frappe.get_doc("Sales Invoice", document_name)
+        company = sales_invoice.company
 
-    if invoice_type in ("Credit Note", "Both"):
-        fetch_etims_credit_notes(
-            request_data, settings_name, document_name=document_name
-        )
+        if invoice_type in ("Sales Invoice", "Both"):
+            fetch_etims_sales_invoices(
+                request_data,
+                settings_name,
+                document_name=document_name,
+                company=company,
+            )
+
+        if invoice_type in ("Credit Note", "Both"):
+            fetch_etims_credit_notes(
+                request_data,
+                settings_name,
+                document_name=document_name,
+                company=company,
+            )
+
+    else:
+        settings = frappe.get_doc(SETTINGS_DOCTYPE_NAME, settings_name)
+
+        for mapping in settings.organisation_mapping:
+            company = mapping.company
+
+            if invoice_type in ("Sales Invoice", "Both"):
+                fetch_etims_sales_invoices(request_data, settings_name, company=company)
+
+            if invoice_type in ("Credit Note", "Both"):
+                fetch_etims_credit_notes(request_data, settings_name, company=company)
 
 
 @frappe.whitelist()
@@ -691,6 +713,7 @@ def fetch_etims_sales_invoices(
     request_data: str | dict = None,
     settings_name: str = None,
     document_name: str = None,
+    company: str = None,
 ) -> None:
     request_data = parse_request_data(request_data)
 
@@ -705,6 +728,7 @@ def fetch_etims_sales_invoices(
         settings_name=settings_name,
         document_name=document_name,
         handler_function=fetch_etims_sales_invoices_on_success,
+        company=company,
     )
 
 
@@ -713,6 +737,7 @@ def fetch_etims_credit_notes(
     request_data: str | dict = None,
     settings_name: str = None,
     document_name: str = None,
+    company: str = None,
 ) -> None:
     # request_data = parse_request_data(request_data)
     request_data = {}
@@ -731,6 +756,7 @@ def fetch_etims_credit_notes(
         document_name=document_name,
         handler_function=fetch_etims_credit_notes_on_success,
         page_size=50,
+        company=company,
     )
 
 

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/navari_kra_etims_settings/navari_kra_etims_settings.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/navari_kra_etims_settings/navari_kra_etims_settings.js
@@ -87,7 +87,6 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
               });
             },
             error: (error) => {
-              // Error Handling is Defered to the Server
               frappe.msgprint({
                 title: __("Error"),
                 indicator: "red",
@@ -135,7 +134,6 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
                   });
                 },
                 error: (error) => {
-                  // Error Handling is Defered to the Server
                   frappe.msgprint({
                     title: __("Error"),
                     indicator: "red",
@@ -145,7 +143,6 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
               });
             },
             error: (error) => {
-              // Error Handling is Defered to the Server
               frappe.msgprint({
                 title: __("Error"),
                 indicator: "red",
@@ -285,7 +282,6 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
       },
       __("eTims Actions"),
     );
-
     frappe.call({
       method:
         "kenya_compliance_via_slade.kenya_compliance_via_slade.utils.check_hanging_custom_fields",
@@ -293,7 +289,84 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
         let fields = r.message || [];
         if (fields.length > 0) {
           frm.add_custom_button(
-            __("Clear Hanging Custom Fields"),
+            __("Run Data Migration"),
+            function () {
+              let d = new frappe.ui.Dialog({
+                title: __("Configure Data Migration Range"),
+                fields: [
+                  {
+                    label: __("Migrate Records From"),
+                    fieldname: "from_date",
+                    fieldtype: "Date",
+                    default: frappe.datetime.add_months(
+                      frappe.datetime.get_today(),
+                      -12,
+                    ),
+                    reqd: 1,
+                    description: __(
+                      "Historical cutoff boundary for heavy transaction tables (Sales Invoice, Stock Ledger, etc.).",
+                    ),
+                  },
+                ],
+                primary_action_label: __("Start Pipeline"),
+                primary_action: function (values) {
+                  d.hide();
+
+                  frappe.show_progress(
+                    __("Migrating Legacy eTims Data"),
+                    1,
+                    100,
+                    __("Initiating background job component..."),
+                  );
+
+                  frappe.call({
+                    method:
+                      "kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_csf_ke_data.migrate",
+                    args: {
+                      from_date: values.from_date,
+                    },
+                    callback: function (response) {
+                      frappe.show_alert({
+                        title: __("Pipeline Initialized"),
+                        indicator: "green",
+                        message: __(
+                          "Background worker dispatched. Reloading context...",
+                        ),
+                      });
+
+                      frappe.msgprint({
+                        title: __("Migration Job Started"),
+                        indicator: "blue",
+                        message: __(`
+                          The migration process is running asynchronously in the background.<br><br>
+                          <b>How to Cancel / Stop:</b><br>
+                          If you need to terminate this process, you can track and stop it directly via the 
+                          <a href="/app/rq-job?job_name=%5B%22like%22%2C%22%25kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_csf_ke_data.run_heavy_migrations%25%22%5D" target="_blank" rel="noopener noreferrer" style="text-decoration: underline; font-weight: bold;">
+                            Active RQ Migration Jobs
+                          </a> view by clicking <b>Force Stop Job</b> on the running task instance under the worker queue.
+                        `),
+                      });
+                    },
+                    error: function (error) {
+                      frappe.hide_progress();
+                      frappe.msgprint({
+                        title: __("Pipeline Error"),
+                        indicator: "red",
+                        message: __(
+                          "Failed to queue background worker process. Check error logs.",
+                        ),
+                      });
+                    },
+                  });
+                },
+              });
+              d.show();
+            },
+            __("CSF KE Migration"),
+          );
+
+          frm.add_custom_button(
+            __("Clear Hanging Fields"),
             function () {
               let field_list_html = fields
                 .map(
@@ -303,9 +376,13 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
                 .join("");
 
               frappe.confirm(
-                __(
-                  `Are you sure you want to delete the following hanging custom fields?<br><br><ul style="max-height: 200px; overflow-y: auto;">${field_list_html}</ul>`,
-                ),
+                __(`
+              <div class="alert alert-warning" style="margin-bottom: 15px;">
+                <strong>⚠️ Warning:</strong> Ensure you have successfully executed the <b>Run Data Migration</b> routine first. Dropping these custom fields before running migration will result in permanent loss of legacy eTims history.
+              </div>
+              Are you sure you want to delete the following hanging custom fields?<br><br>
+              <ul style="max-height: 200px; overflow-y: auto;">${field_list_html}</ul>
+            `),
                 function () {
                   frappe.call({
                     method:
@@ -320,8 +397,8 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
                           message: __(res.message.message),
                         });
                         frm.remove_custom_button(
-                          __("Clear Hanging Custom Fields"),
-                          __("eTims Actions"),
+                          __("Clear Hanging Fields"),
+                          __("CSF KE Migration"),
                         );
                       }
                     },
@@ -329,7 +406,7 @@ frappe.ui.form.on("Navari KRA eTims Settings", {
                 },
               );
             },
-            __("eTims Actions"),
+            __("CSF KE Migration"),
           );
         }
       },

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
@@ -607,6 +607,7 @@ function addCustomButtons(frm, activeSetting, summaryData) {
           args: {
             settings_name: settings_name,
             document_name: frm.doc.name,
+            company: frm.doc.company,
             request_data: {
               reference_number: frm.doc.is_return
                 ? frm.doc.return_against
@@ -656,13 +657,13 @@ function showCorrectionDialog(frm, activeSetting, summaryData) {
     etimsCreditAmount = Math.abs(etimsCreditAmount);
   }
 
-  const erpVat = flt(summaryData?.erp_tax_amount || 0);
-  const etimsVat = flt(summaryData?.etims_total_tax || 0);
+  const erpTax = flt(summaryData?.erp_tax_amount || 0);
+  const etimsTax = flt(summaryData?.etims_total_tax || 0);
   const difference =
     erpInvoiceAmount -
     erpCreditAmount -
     (etimsInvoiceAmount - etimsCreditAmount);
-  const vatDifference = flt(summaryData?.tax_difference || 0);
+  const taxDifference = flt(summaryData?.tax_difference || 0);
   const erpNet = erpInvoiceAmount - erpCreditAmount;
   const etimsNet = etimsInvoiceAmount - etimsCreditAmount;
   const differencePercent =
@@ -679,9 +680,9 @@ function showCorrectionDialog(frm, activeSetting, summaryData) {
     );
   }
 
-  if (Math.abs(vatDifference) > 1) {
+  if (Math.abs(taxDifference) > 1) {
     issueNotes.push(
-      `<li style="margin-bottom:10px;">ERPNext VAT totals do not match eTIMS VAT totals.</li>`,
+      `<li style="margin-bottom:10px;">ERPNext Tax totals do not match eTIMS Tax totals.</li>`,
     );
   }
 
@@ -751,8 +752,8 @@ function showCorrectionDialog(frm, activeSetting, summaryData) {
                 <div style="margin-top:8px;font-size:24px;font-weight:700;color:#991b1b;">${formatValue(difference)}</div>
               </div>
               <div style="padding:16px;border-radius:10px;border:1px solid #fecaca;background:#fef2f2;">
-                <div style="font-size:12px;color:#991b1b;">VAT Difference</div>
-                <div style="margin-top:8px;font-size:24px;font-weight:700;color:#991b1b;">${formatValue(vatDifference)}</div>
+                <div style="font-size:12px;color:#991b1b;">Tax Difference</div>
+                <div style="margin-top:8px;font-size:24px;font-weight:700;color:#991b1b;">${formatValue(taxDifference)}</div>
               </div>
               <div style="padding:16px;border-radius:10px;border:1px solid #e5e7eb;background:#ffffff;">
                 <div style="font-size:12px;color:#64748b;">ERPNext Net Value</div>

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
@@ -125,68 +125,171 @@ async function fetchAndRenderSummary(frm, activeSetting, eligibilityData) {
       return null;
     }
 
-    const postingDate = frappe.datetime.str_to_obj(frm.doc.posting_date);
-    const creationDate = frappe.datetime.str_to_obj(
-      (frm.doc.creation || "").split(" ")[0],
-    );
-    const startDate =
-      creationDate && creationDate < postingDate
-        ? frappe.datetime.obj_to_str(creationDate)
-        : frappe.datetime.add_months(frm.doc.posting_date, -3);
-    const endDate = frappe.datetime.get_today();
-
-    const referenceNumber =
+    const invoiceName =
       frm.doc.is_return && frm.doc.return_against
         ? frm.doc.return_against
         : frm.doc.name;
 
     const response = await frappe.call({
-      method: "frappe.desk.query_report.run",
-      args: {
-        report_name: "eTIMS Sales Ledger",
-        filters: {
-          company: frm.doc.company,
-          from_date: startDate,
-          to_date: endDate,
-          sales_invoice: referenceNumber,
-          show_details: 1,
-        },
-      },
+      method:
+        "kenya_compliance_via_slade.kenya_compliance_via_slade.overrides.server.sales_invoice.get_single_invoice_reconciliation",
+      args: { invoice_name: invoiceName },
       freeze: false,
     });
 
-    const rows = response.message.result || [];
-    const totalRow = rows.find((d) => d.sales_invoice === "TOTAL") || {};
-    let detailRows = rows.filter(
-      (d) =>
-        d.indent === 1 &&
-        (flt2(d.etims_invoice_amount) ||
-          flt2(d.etims_credit_amount) ||
-          flt2(d.etims_total_tax)),
-    );
+    const data = response.message || {};
 
-    if (frm.doc.is_return && frm.doc.return_against) {
-      const matchedCreditNote = detailRows.find(
-        (row) =>
-          row.type === "Credit Note" && row.reference_number === frm.doc.name,
-      );
-
-      if (matchedCreditNote) {
-        detailRows = [matchedCreditNote];
-      } else {
-        const unmatchedCreditNote = {
-          invoice_date: frm.doc.posting_date,
-          customer: frm.doc.customer_name,
-          type: "Credit Note (Unmatched)",
-          etims_invoice_amount: 0,
-          etims_credit_amount: Math.abs(flt2(frm.doc.grand_total)),
-          etims_total_tax: Math.abs(flt2(frm.doc.total_taxes_and_charges)),
-          reference_number: "Not Found on eTIMS",
-          is_signed: 0,
-        };
-        detailRows = [unmatchedCreditNote];
-      }
+    if (!data || !data.details) {
+      renderErrorBlock(htmlField);
+      return null;
     }
+
+    if (frm.doc.is_return) {
+      htmlField.$wrapper.html(`
+        ${SHARED_ETIMS_STYLES}
+        <div class="etims-root">
+          <div class="etims-hero">
+            <div>
+              <div class="etims-hero-title">Return / Credit Note - Original Invoice Reconciliation</div>
+              <div class="etims-hero-sub">${data.from_date} — ${data.to_date}</div>
+              <div style="margin-top:8px;font-size:12px;color:var(--text-muted);">
+                Original Invoice: <strong>${frappe.utils.escape_html(invoiceName)}</strong>
+              </div>
+            </div>
+            <span class="etims-pill etims-pill-info">
+              ${ETIMS_ICONS.info} Return Invoice
+            </span>
+          </div>
+
+          <div class="etims-stats-grid-2x2">
+            <div class="etims-stat-card">
+              <div class="etims-stat-header">Invoices</div>
+              <div class="etims-stat-body">
+                <div class="etims-compare-row"><span class="etims-compare-label">ERP</span><span class="etims-compare-value erp">${fmt(data.erp_invoice_amount)}</span></div>
+                <div class="etims-compare-row"><span class="etims-compare-label">eTIMS</span><span class="etims-compare-value etims">${fmt(data.etims_invoice_amount)}</span></div>
+                <div class="etims-diff-section">
+                  <div class="etims-diff-row"><span class="etims-diff-label">Difference</span><span class="etims-diff-amount ${data.invoice_difference >= 0 ? "positive" : "negative"}">${fmt(data.invoice_difference)}</span></div>
+                  <div class="etims-diff-row"><span class="etims-diff-label">Difference %</span><div><span class="etims-diff-percent" style="font-size:13px;font-weight:700;">${data.invoice_diff_percent.toFixed(2)}%</span></div></div>
+                </div>
+              </div>
+            </div>
+
+            <div class="etims-stat-card">
+              <div class="etims-stat-header">Credit Notes</div>
+              <div class="etims-stat-body">
+                <div class="etims-compare-row"><span class="etims-compare-label">ERP</span><span class="etims-compare-value erp">${fmt(data.erp_credit_amount)}</span></div>
+                <div class="etims-compare-row"><span class="etims-compare-label">eTIMS</span><span class="etims-compare-value etims">${fmt(data.etims_credit_amount)}</span></div>
+                <div class="etims-diff-section">
+                  <div class="etims-diff-row"><span class="etims-diff-label">Difference</span><span class="etims-diff-amount ${data.credit_difference >= 0 ? "positive" : "negative"}">${fmt(data.credit_difference)}</span></div>
+                  <div class="etims-diff-row"><span class="etims-diff-label">Difference %</span><div><span class="etims-diff-percent" style="font-size:13px;font-weight:700;">${data.credit_diff_percent.toFixed(2)}%</span></div></div>
+                </div>
+              </div>
+            </div>
+
+            <div class="etims-stat-card">
+              <div class="etims-stat-header">Net Values</div>
+              <div class="etims-stat-body">
+                <div class="etims-compare-row"><span class="etims-compare-label">ERP Net</span><span class="etims-compare-value erp">${fmt(data.erp_net_amount)}</span></div>
+                <div class="etims-compare-row"><span class="etims-compare-label">eTIMS Net</span><span class="etims-compare-value etims">${fmt(data.etims_net_amount)}</span></div>
+                <div class="etims-diff-section">
+                  <div class="etims-diff-row"><span class="etims-diff-label">Difference</span><span class="etims-diff-amount ${data.net_difference >= 0 ? "positive" : "negative"}">${fmt(data.net_difference)}</span></div>
+                  <div class="etims-diff-row"><span class="etims-diff-label">Difference %</span><div><span class="etims-diff-percent" style="font-size:13px;font-weight:700;">${data.net_diff_percent.toFixed(2)}%</span></div></div>
+                </div>
+              </div>
+            </div>
+
+            <div class="etims-stat-card">
+              <div class="etims-stat-header">Tax</div>
+              <div class="etims-stat-body">
+                <div class="etims-compare-row"><span class="etims-compare-label">ERP Tax</span><span class="etims-compare-value erp">${fmt(data.erp_tax_amount)}</span></div>
+                <div class="etims-compare-row"><span class="etims-compare-label">eTIMS Tax</span><span class="etims-compare-value etims">${fmt(data.etims_tax_amount)}</span></div>
+                <div class="etims-diff-section">
+                  <div class="etims-diff-row"><span class="etims-diff-label">Difference</span><span class="etims-diff-amount ${data.tax_difference >= 0 ? "positive" : "negative"}">${fmt(data.tax_difference)}</span></div>
+                  <div class="etims-diff-row"><span class="etims-diff-label">Difference %</span><div><span class="etims-diff-percent" style="font-size:13px;font-weight:700;">${data.tax_diff_percent ? data.tax_diff_percent.toFixed(2) : "0.00"}%</span></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="etims-card">
+            <div class="etims-card-header">
+              <span class="etims-card-header-title">Transaction Records (Original Invoice)</span>
+              <span class="etims-pill etims-pill-neutral">${data.details.length} entr${data.details.length !== 1 ? "ies" : "y"}</span>
+            </div>
+            <div class="etims-table-wrap">
+              <table class="etims-table">
+                <thead>
+                  <tr><th>Date</th><th>Customer</th><th>Type</th><th class="r">Invoice Amt</th><th class="r">Credit Amt</th><th class="r">Tax</th><th>Reference</th><th class="c">Status</th></tr>
+                </thead>
+                <tbody>
+                  ${data.details
+                    .map(
+                      (row, i) => `
+                    <tr class="${i % 2 === 0 ? "row-even" : "row-odd"}">
+                      <td class="muted">${frappe.datetime.str_to_user(row.invoice_date)}</td>
+                      <td class="bold">${frappe.utils.escape_html(row.customer || "—")}</td>
+                      <td><span class="etims-type-chip">${row.type || "—"}</span></td>
+                      <td class="r mono">${row.type === "Sales Invoice" ? fmt(row.amount) : "—"}</td>
+                      <td class="r mono" style="color:var(--text-muted);">${row.type === "Credit Note" ? fmt(row.amount) : "—"}</td>
+                      <td class="r mono" style="color:var(--text-muted);">${row.type === "Sales Invoice" ? fmt(row.tax) : "—"}</td>
+                      <td class="muted" style="font-family:monospace;font-size:11px;">${frappe.utils.escape_html(row.reference_number || "—")}</td>
+                      <td class="c">${row.is_signed ? `<span class="etims-pill etims-pill-success">${ETIMS_ICONS.check} Signed</span>` : `<span class="etims-pill etims-pill-danger">${ETIMS_ICONS.x} Unsigned</span>`}</td>
+                    </tr>
+                  `,
+                    )
+                    .join("")}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div class="etims-card" style="border:2px solid #fcd34d;background:#fffbeb;">
+            <div class="etims-card-header" style="background:#fef3c7;border-bottom-color:#fcd34d;">
+              <div style="display:flex;align-items:center;gap:10px;color:#92400e;">
+                ${ETIMS_ICONS.info}
+                <span class="etims-card-header-title" style="color:#92400e;">Return Invoice Information</span>
+              </div>
+              <span class="etims-pill etims-pill-warn">Credit Note</span>
+            </div>
+            <div class="etims-card-body">
+              <p style="margin:0;font-size:13px;color:var(--text-color);line-height:1.8;">
+                <strong>Return Invoice:</strong> ${frappe.utils.escape_html(frm.doc.name)}<br>
+                <strong>Original Invoice:</strong> ${frappe.utils.escape_html(invoiceName)}<br>
+                <strong>Return Amount:</strong> ${fmt(Math.abs(frm.doc.grand_total))}<br>
+                <strong>Return Tax:</strong> ${fmt(Math.abs(frm.doc.total_taxes_and_charges))}
+              </p>
+            </div>
+          </div>
+        </div>
+      `);
+
+      return {
+        hasSignificantMismatch: data.has_significant_mismatch,
+        invoiceDiffPercent: data.invoice_diff_percent,
+        creditDiffPercent: data.credit_diff_percent,
+        netDiffPercent: data.net_diff_percent,
+        erp_invoice_period_amount: data.erp_invoice_amount,
+        erp_credit_period_amount: data.erp_credit_amount,
+        etims_invoice_amount: data.etims_invoice_amount,
+        etims_credit_amount: data.etims_credit_amount,
+        difference: data.net_difference,
+        tax_difference: data.tax_difference,
+        erp_tax_amount: data.erp_tax_amount,
+        etims_total_tax: data.etims_tax_amount,
+        tax_diff_percent: data.tax_diff_percent || 0,
+      };
+    }
+
+    const detailRows = data.details.map((d) => ({
+      invoice_date: d.invoice_date,
+      customer: d.customer,
+      type: d.type,
+      etims_invoice_amount: d.type === "Sales Invoice" ? d.amount : 0,
+      etims_credit_amount: d.type === "Credit Note" ? d.amount : 0,
+      etims_total_tax: d.type === "Sales Invoice" ? d.tax : 0,
+      reference_number: d.reference_number,
+      is_signed: d.is_signed,
+    }));
 
     const badge = (ok) =>
       ok
@@ -202,7 +305,7 @@ async function fetchAndRenderSummary(frm, activeSetting, eligibilityData) {
         <div class="etims-table-wrap">
           <table class="etims-table">
             <thead>
-              <tr><th>Date</th><th>Customer</th><th>Type</th><th class="r">Invoice Amt</th><th class="r">Credit Amt</th><th class="r">VAT</th><th>Reference</th><th class="c">Status</th></tr>
+              <tr><th>Date</th><th>Customer</th><th>Type</th><th class="r">Invoice Amt</th><th class="r">Credit Amt</th><th class="r">Tax</th><th>Reference</th><th class="c">Status</th></tr>
             </thead>
             <tbody>
               ${
@@ -241,115 +344,44 @@ async function fetchAndRenderSummary(frm, activeSetting, eligibilityData) {
       return null;
     }
 
-    if (frm.doc.is_return) {
-      htmlField.$wrapper.html(`
-        ${SHARED_ETIMS_STYLES}
-        <div class="etims-root">
-          <div class="etims-empty">
-            <div class="etims-empty-icon" style="color:#d97706;background:#fffbeb;">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M9 14L4 9l5-5M4 9h11a6 6 0 010 12h-2"/></svg>
-            </div>
-            <div class="etims-empty-title">Return Invoice</div>
-            <div class="etims-empty-sub">
-              This is a credit note / return transaction. Please refer to the original invoice 
-              for the complete eTIMS reconciliation ledger and dashboard metrics.
-            </div>
-          </div>
-        </div>
-      `);
-      return {
-        hasSignificantMismatch: false,
-        invoiceDiffPercent: 0,
-        creditDiffPercent: 0,
-        netDiffPercent: 0,
-      };
-    }
-
-    let erpInvoiceAmount = flt2(totalRow.erp_invoice_period_amount || 0);
-    let etimsInvoiceAmount = flt2(totalRow.etims_invoice_amount || 0);
-    let erpCreditAmount = flt2(totalRow.erp_credit_period_amount || 0);
-    let etimsCreditAmount = flt2(totalRow.etims_credit_amount || 0);
-
-    if (frm.doc.is_return) {
-      const returnGrandTotal = Math.abs(flt2(frm.doc.grand_total));
-      const returnTaxTotal = Math.abs(flt2(frm.doc.total_taxes_and_charges));
-
-      erpInvoiceAmount = 0;
-      erpCreditAmount = returnGrandTotal;
-      etimsInvoiceAmount = 0;
-      etimsCreditAmount =
-        detailRows.length > 0 &&
-        detailRows[0].type !== "Credit Note (Unmatched)"
-          ? Math.abs(flt2(detailRows[0].etims_credit_amount))
-          : 0;
-
-      if (
-        detailRows.length > 0 &&
-        detailRows[0].type === "Credit Note (Unmatched)"
-      ) {
-        etimsCreditAmount = 0;
-      }
-    }
-
-    const invoiceDifference = erpInvoiceAmount - etimsInvoiceAmount;
-    const invoiceDiffPercent =
-      erpInvoiceAmount > 0
-        ? (Math.abs(invoiceDifference) / erpInvoiceAmount) * 100
-        : 0;
-
-    const creditDifference = erpCreditAmount - etimsCreditAmount;
-    const creditDiffPercent =
-      erpCreditAmount > 0
-        ? (Math.abs(creditDifference) / erpCreditAmount) * 100
-        : 0;
-
-    const erpNetAmount = erpInvoiceAmount + erpCreditAmount;
-    const etimsNetAmount = etimsInvoiceAmount + etimsCreditAmount;
-    const netDifference = erpNetAmount - etimsNetAmount;
-    const netDiffPercent =
-      Math.abs(erpNetAmount) > 0
-        ? (Math.abs(netDifference) / Math.abs(erpNetAmount)) * 100
-        : 0;
-
-    const hasSignificantMismatch =
-      invoiceDiffPercent > 0.5 ||
-      creditDiffPercent > 0.5 ||
-      netDiffPercent > 0.5;
-
     renderSummaryDashboard(htmlField, {
-      startDate,
-      endDate,
-      hasSignificantMismatch,
-      erpInvoiceAmount,
-      etimsInvoiceAmount,
-      invoiceDifference,
-      invoiceDiffPercent,
-      erpCreditAmount,
-      etimsCreditAmount,
-      creditDifference,
-      creditDiffPercent,
-      erpNetAmount,
-      etimsNetAmount,
-      netDifference,
-      netDiffPercent,
+      startDate: data.from_date,
+      endDate: data.to_date,
+      hasSignificantMismatch: data.has_significant_mismatch,
+      erpInvoiceAmount: data.erp_invoice_amount,
+      etimsInvoiceAmount: data.etims_invoice_amount,
+      invoiceDifference: data.invoice_difference,
+      invoiceDiffPercent: data.invoice_diff_percent,
+      erpCreditAmount: data.erp_credit_amount,
+      etimsCreditAmount: data.etims_credit_amount,
+      creditDifference: data.credit_difference,
+      creditDiffPercent: data.credit_diff_percent,
+      erpNetAmount: data.erp_net_amount,
+      etimsNetAmount: data.etims_net_amount,
+      netDifference: data.net_difference,
+      netDiffPercent: data.net_diff_percent,
+      erpTaxAmount: data.erp_tax_amount,
+      etimsTaxAmount: data.etims_tax_amount,
+      taxDifference: data.tax_difference,
+      taxDiffPercent: data.tax_diff_percent || 0,
       tableHtml,
       fmt,
     });
 
     return {
-      hasSignificantMismatch,
-      invoiceDiffPercent,
-      creditDiffPercent,
-      netDiffPercent,
-      totalRow,
-      erp_invoice_period_amount: erpInvoiceAmount,
-      erp_credit_period_amount: erpCreditAmount,
-      etims_invoice_amount: etimsInvoiceAmount,
-      etims_credit_amount: etimsCreditAmount,
-      difference: netDifference,
-      tax_difference: flt2(totalRow.tax_difference || 0),
-      erp_tax_amount: flt2(totalRow.erp_tax_amount || 0),
-      etims_total_tax: flt2(totalRow.etims_total_tax || 0),
+      hasSignificantMismatch: data.has_significant_mismatch,
+      invoiceDiffPercent: data.invoice_diff_percent,
+      creditDiffPercent: data.credit_diff_percent,
+      netDiffPercent: data.net_diff_percent,
+      erp_invoice_period_amount: data.erp_invoice_amount,
+      erp_credit_period_amount: data.erp_credit_amount,
+      etims_invoice_amount: data.etims_invoice_amount,
+      etims_credit_amount: data.etims_credit_amount,
+      difference: data.net_difference,
+      tax_difference: data.tax_difference,
+      erp_tax_amount: data.erp_tax_amount,
+      etims_total_tax: data.etims_tax_amount,
+      tax_diff_percent: data.tax_diff_percent || 0,
     };
   } catch (error) {
     console.error("eTIMS summary error:", error);
@@ -454,7 +486,7 @@ function renderSummaryDashboard(htmlField, data) {
         </span>
       </div>
 
-      <div class="etims-stats-grid">
+      <div class="etims-stats-grid-2x2">
         <div class="etims-stat-card">
           <div class="etims-stat-header">Invoices</div>
           <div class="etims-stat-body">
@@ -487,6 +519,18 @@ function renderSummaryDashboard(htmlField, data) {
             <div class="etims-diff-section">
               <div class="etims-diff-row"><span class="etims-diff-label">Difference</span><span class="etims-diff-amount ${data.netDifference >= 0 ? "positive" : "negative"}">${data.fmt(data.netDifference)}</span></div>
               <div class="etims-diff-row"><span class="etims-diff-label">Difference %</span><div><span class="etims-diff-percent" style="font-size:13px;font-weight:700;">${data.netDiffPercent.toFixed(2)}%</span></div></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="etims-stat-card">
+          <div class="etims-stat-header">Tax</div>
+          <div class="etims-stat-body">
+            <div class="etims-compare-row"><span class="etims-compare-label">ERP Tax</span><span class="etims-compare-value erp">${data.fmt(data.erpTaxAmount)}</span></div>
+            <div class="etims-compare-row"><span class="etims-compare-label">eTIMS Tax</span><span class="etims-compare-value etims">${data.fmt(data.etimsTaxAmount)}</span></div>
+            <div class="etims-diff-section">
+              <div class="etims-diff-row"><span class="etims-diff-label">Difference</span><span class="etims-diff-amount ${data.taxDifference >= 0 ? "positive" : "negative"}">${data.fmt(data.taxDifference)}</span></div>
+              <div class="etims-diff-row"><span class="etims-diff-label">Difference %</span><div><span class="etims-diff-percent" style="font-size:13px;font-weight:700;">${data.taxDiffPercent ? data.taxDiffPercent.toFixed(2) : "0.00"}%</span></div></div>
             </div>
           </div>
         </div>
@@ -1020,9 +1064,9 @@ const SHARED_ETIMS_STYLES = `
     html[data-theme="dark"] .etims-pill-neutral { background: rgba(107,114,128,0.2); color: #9ca3af; }
     html[data-theme="dark"] .etims-pill-info    { background: rgba(59,130,246,0.2); color: #60a5fa; }
 
-    .etims-stats-grid {
+    .etims-stats-grid-2x2 {
       display: grid;
-      grid-template-columns: repeat(3, 1fr);
+      grid-template-columns: repeat(2, 1fr);
       gap: 16px;
     }
     .etims-stat-card {
@@ -1379,6 +1423,12 @@ const SHARED_ETIMS_STYLES = `
     }
     html[data-theme="dark"] .btn-etims:hover {
       background: #1d4ed8;
+    }
+
+    @media (max-width: 768px) {
+      .etims-stats-grid-2x2 {
+        grid-template-columns: 1fr;
+      }
     }
   </style>
 `;

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/sales_invoice.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/sales_invoice.py
@@ -1,5 +1,8 @@
 import frappe
+from erpnext.setup.utils import get_exchange_rate
 from frappe.model.document import Document
+from frappe.query_builder import DocType
+from frappe.utils import add_to_date, flt, getdate
 
 from ...utils import (
     apply_item_taxes_and_codes,
@@ -50,8 +53,252 @@ def before_cancel(doc: Document, method: str = None) -> None:
 
 
 @frappe.whitelist()
-def send_invoice_details(name: str) -> None:
-    doc = frappe.get_doc("Sales Invoice", name)
-    if doc.is_opening == "Yes":
-        return
-    generic_invoices_on_submit_override(doc, "Sales Invoice")
+def get_single_invoice_reconciliation(invoice_name):
+    if not invoice_name:
+        frappe.throw("Invoice name is required")
+
+    invoice = frappe.get_cached_doc("Sales Invoice", invoice_name)
+    company_currency = frappe.db.get_value(
+        "Company", invoice.company, "default_currency"
+    )
+    currency = invoice.currency
+
+    posting_date = getdate(invoice.posting_date)
+    creation_date = getdate(invoice.creation) if invoice.creation else None
+
+    if creation_date and creation_date < posting_date:
+        from_date = creation_date
+    else:
+        from_date = add_to_date(posting_date, months=-3)
+
+    to_date = getdate(add_to_date(posting_date, days=1))
+
+    erp_data = _get_erp_amounts(invoice, company_currency, currency, from_date, to_date)
+    etims_data = _get_etims_data(invoice, from_date, to_date)
+
+    return _calculate_reconciliation_summary(
+        invoice, erp_data, etims_data, from_date, to_date, company_currency, currency
+    )
+
+
+def _get_erp_amounts(invoice, company_currency, currency, from_date, to_date):
+    SI = DocType("Sales Invoice")
+
+    conversion_rate = 1.0
+    if currency != "KES" and company_currency != "KES":
+        conversion_rate = get_exchange_rate(currency, "KES", invoice.posting_date)
+
+    if currency == "KES":
+        invoice_amount = flt(invoice.grand_total)
+        invoice_tax = flt(invoice.total_taxes_and_charges)
+    elif company_currency == "KES":
+        invoice_amount = flt(invoice.base_grand_total)
+        invoice_tax = flt(invoice.base_total_taxes_and_charges)
+    else:
+        invoice_amount = flt(invoice.grand_total) * conversion_rate
+        invoice_tax = flt(invoice.total_taxes_and_charges) * conversion_rate
+
+    in_period = getdate(from_date) <= getdate(invoice.posting_date) <= getdate(to_date)
+    invoice_period_amount = invoice_amount if in_period else 0
+    invoice_tax_period = invoice_tax if in_period else 0
+
+    credit_notes = frappe.get_all(
+        "Sales Invoice",
+        filters={"is_return": 1, "return_against": invoice.name, "docstatus": 1},
+        fields=[
+            "name",
+            "grand_total",
+            "base_grand_total",
+            "total_taxes_and_charges",
+            "base_total_taxes_and_charges",
+            "posting_date",
+            "currency",
+        ],
+    )
+
+    credit_amount_all = 0
+    credit_amount_period = 0
+    credit_tax_period = 0
+
+    for cn in credit_notes:
+        if cn.currency == "KES":
+            cn_amount = flt(cn.grand_total)
+            cn_tax = flt(cn.total_taxes_and_charges)
+        elif company_currency == "KES":
+            cn_amount = flt(cn.base_grand_total)
+            cn_tax = flt(cn.base_total_taxes_and_charges)
+        else:
+            cn_rate = get_exchange_rate(cn.currency, "KES", cn.posting_date)
+            cn_amount = flt(cn.grand_total) * cn_rate
+            cn_tax = flt(cn.total_taxes_and_charges) * cn_rate
+
+        credit_amount_all += cn_amount
+
+        if getdate(from_date) <= getdate(cn.posting_date) <= getdate(to_date):
+            credit_amount_period += cn_amount
+            credit_tax_period += cn_tax
+
+    return {
+        "invoice_amount": invoice_amount,
+        "invoice_period_amount": invoice_period_amount,
+        "invoice_tax": invoice_tax,
+        "invoice_tax_period": invoice_tax_period,
+        "credit_amount_all": credit_amount_all,
+        "credit_amount_period": credit_amount_period,
+        "credit_tax_period": credit_tax_period,
+        "from_date": from_date,
+        "to_date": to_date,
+    }
+
+
+def _get_etims_data(invoice, from_date, to_date):
+    Ledger = DocType("eTIMS Sales Ledger Entry")
+    reference_number = invoice.return_against if invoice.is_return else invoice.name
+
+    query = (
+        frappe.qb.from_(Ledger)
+        .select(
+            Ledger.name,
+            Ledger.sales_invoice,
+            Ledger.invoice_date,
+            Ledger.type,
+            Ledger.total_gross_amount,
+            Ledger.total_vat,
+            Ledger.customer_name,
+            Ledger.reference_number,
+            Ledger.scu_invoice_number,
+            Ledger.is_signed,
+        )
+        .where(Ledger.company == invoice.company)
+        .where(
+            (Ledger.sales_invoice == invoice.name)
+            | (Ledger.reference_number == reference_number)
+        )
+        .where(Ledger.invoice_date.between(from_date, to_date))
+    )
+
+    entries = query.run(as_dict=True)
+
+    etims_invoice_amount = 0
+    etims_credit_amount = 0
+    etims_tax_amount = 0
+    etims_credit_tax = 0
+    details = []
+
+    for entry in entries:
+        if entry.type == "Sales Invoice":
+            etims_invoice_amount += flt(entry.total_gross_amount)
+            etims_tax_amount += flt(entry.total_vat)
+        elif entry.type == "Credit Note":
+            etims_credit_amount += abs(flt(entry.total_gross_amount))
+            etims_credit_tax += abs(flt(entry.total_vat))
+
+        details.append(
+            {
+                "invoice_date": entry.invoice_date,
+                "customer": entry.customer_name,
+                "type": entry.type,
+                "reference_number": entry.reference_number,
+                "scu_invoice_number": entry.scu_invoice_number,
+                "is_signed": entry.is_signed,
+                "amount": flt(entry.total_gross_amount)
+                if entry.type == "Sales Invoice"
+                else -abs(flt(entry.total_gross_amount)),
+                "tax": flt(entry.total_vat)
+                if entry.type == "Sales Invoice"
+                else -abs(flt(entry.total_vat)),
+            }
+        )
+
+    if invoice.is_return and not details:
+        details.append(
+            {
+                "invoice_date": invoice.posting_date,
+                "customer": invoice.customer_name,
+                "type": "Credit Note (Unmatched)",
+                "reference_number": "Not Found on eTIMS",
+                "scu_invoice_number": "",
+                "is_signed": 0,
+                "amount": -abs(flt(invoice.grand_total)),
+                "tax": -abs(flt(invoice.total_taxes_and_charges)),
+            }
+        )
+
+    return {
+        "invoice_amount": etims_invoice_amount,
+        "credit_amount": etims_credit_amount,
+        "tax_amount": etims_tax_amount,
+        "credit_tax": etims_credit_tax,
+        "details": details,
+        "total_entries": len(details),
+    }
+
+
+def _calculate_reconciliation_summary(
+    invoice, erp_data, etims_data, from_date, to_date, company_currency, currency
+):
+    erp_invoice = erp_data["invoice_period_amount"]
+    erp_credit = erp_data["credit_amount_period"]
+    erp_tax = erp_data["invoice_tax_period"]
+
+    if invoice.is_return:
+        erp_invoice = 0
+        erp_credit = -abs(flt(invoice.grand_total))
+        erp_tax = -abs(flt(invoice.total_taxes_and_charges))
+
+        if (
+            etims_data["details"]
+            and etims_data["details"][0]["type"] != "Credit Note (Unmatched)"
+        ):
+            etims_credit = -etims_data["credit_amount"]
+        else:
+            etims_credit = 0
+        etims_invoice = 0
+    else:
+        etims_invoice = etims_data["invoice_amount"]
+        etims_credit = -etims_data["credit_amount"]
+
+    invoice_diff = erp_invoice - etims_invoice
+    credit_diff = erp_credit - etims_credit
+
+    erp_net = erp_invoice + erp_credit
+    etims_net = etims_invoice + etims_credit
+    net_diff = erp_net - etims_net
+
+    invoice_diff_pct = (abs(invoice_diff) / erp_invoice * 100) if erp_invoice > 0 else 0
+    credit_diff_pct = (
+        (abs(credit_diff) / abs(erp_credit) * 100) if erp_credit != 0 else 0
+    )
+    net_diff_pct = (abs(net_diff) / abs(erp_net) * 100) if abs(erp_net) > 0 else 0
+
+    has_significant_mismatch = (
+        invoice_diff_pct > 0.5 or credit_diff_pct > 0.5 or net_diff_pct > 0.5
+    )
+
+    tax_diff = etims_data["tax_amount"] - erp_tax
+    tax_diff_pct = (abs(tax_diff) / abs(erp_tax) * 100) if erp_tax != 0 else 0
+
+    return {
+        "has_significant_mismatch": has_significant_mismatch,
+        "invoice_diff_percent": invoice_diff_pct,
+        "credit_diff_percent": credit_diff_pct,
+        "net_diff_percent": net_diff_pct,
+        "tax_diff_percent": tax_diff_pct,
+        "erp_invoice_amount": erp_invoice,
+        "erp_credit_amount": erp_credit,
+        "erp_tax_amount": erp_tax,
+        "erp_net_amount": erp_net,
+        "etims_invoice_amount": etims_invoice,
+        "etims_credit_amount": etims_credit,
+        "etims_tax_amount": etims_data["tax_amount"],
+        "etims_net_amount": etims_net,
+        "invoice_difference": invoice_diff,
+        "credit_difference": credit_diff,
+        "net_difference": net_diff,
+        "tax_difference": tax_diff,
+        "from_date": from_date,
+        "to_date": to_date,
+        "total_etims_entries": etims_data["total_entries"],
+        "details": etims_data["details"],
+        "sent_to_etims": invoice.sent_to_etims,
+    }

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/migrate_csf_ke_data.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/migrate_csf_ke_data.py
@@ -1,116 +1,415 @@
 import frappe
+from frappe.utils import add_years, today
 
-from ..utils import (
-    build_verification_url,
-)
+from ..utils import build_verification_url
 
 
 def execute():
-    migrate_etims_id_mapping()
+    pass
 
-    migrate_doctype_fields(
-        "Item",
-        {
-            "custom_prevent_etims_registration": "etims_prevent_etims_registration",
-            "custom_submission_tries": "etims_submission_tries",
-            "custom_taxation_type": "etims_taxation_type",
-            "custom_taxation_type_name": "etims_taxation_type_name",
-            "custom_item_classification": "etims_item_classification",
-            "custom_item_classification_code": "etims_item_classification_code",
-            "custom_etims_country_of_origin": "etims_country_of_origin",
-            "custom_etims_country_of_origin_code": "etims_country_of_origin_code",
-            "custom_packaging_unit": "etims_packaging_unit",
-            "custom_unit_of_quantity_code": "etims_unit_of_quantity_code",
-            "custom_unit_of_quantity": "etims_unit_of_quantity",
-            "custom_packaging_unit_code": "etims_packaging_unit_code",
-            "custom_item_type": "etims_item_type",
-            "custom_product_type": "etims_product_type",
-            "custom_item_type_name": "etims_item_type_name",
-            "custom_product_type_name": "etims_product_type_name",
-        },
-        "eTims Item Field Migration Failed",
+
+@frappe.whitelist()
+def migrate(from_date=None):
+    if not from_date:
+        from_date = add_years(today(), -1)
+
+    frappe.cache().set_value(
+        "etims_migration_progress",
+        {"percent": 1, "description": "Initializing Data Migration..."},
+    )
+    frappe.enqueue(
+        method="kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_csf_ke_data.run_heavy_migrations",
+        queue="long",
+        timeout=4000,
+        now=frappe.flags.in_test,
+        from_date=from_date,
     )
 
-    migrate_doctype_fields(
-        "Item Group",
-        {
-            "custom_prevent_etims_registration": "etims_prevent_etims_registration",
-            "custom_taxation_type": "etims_taxation_type",
-            "custom_taxation_type_name": "etims_taxation_type_name",
-            "custom_item_classification": "etims_item_classification",
-            "custom_item_classification_code": "etims_item_classification_code",
-            "custom_etims_country_of_origin": "etims_country_of_origin",
-            "custom_etims_country_of_origin_code": "etims_country_of_origin_code",
-            "custom_packaging_unit": "etims_packaging_unit",
-            "custom_unit_of_quantity_code": "etims_unit_of_quantity_code",
-            "custom_unit_of_quantity": "etims_unit_of_quantity",
-            "custom_packaging_unit_code": "etims_packaging_unit_code",
-            "custom_item_type": "etims_item_type",
-            "custom_product_type": "etims_product_type",
-            "custom_item_type_name": "etims_item_type_name",
-            "custom_product_type_name": "etims_product_type_name",
-        },
-        "eTims Item Group Field Migration Failed",
+
+@frappe.whitelist()
+def get_migration_status():
+    status = frappe.cache().get_value("etims_migration_progress")
+    if not status:
+        return {"percent": 0, "description": "No active migration found."}
+    return status
+
+
+def update_migration_progress(percent, description):
+    frappe.cache().set_value(
+        "etims_migration_progress", {"percent": percent, "description": description}
+    )
+    frappe.publish_progress(
+        percent,
+        title="Migrating Legacy eTims Data",
+        description=description,
     )
 
-    migrate_doctype_fields(
-        "Item Tax Template",
-        {
-            "custom_etims_taxation_type": "etims_taxation_type",
-        },
-        "eTims Item Tax Template Field Migration Failed",
-    )
 
-    migrate_doctype_fields(
-        "Sales Taxes and Charges Template",
-        {
-            "custom_etims_taxation_type": "etims_taxation_type",
-        },
-        "eTims Sales Taxes and Charges Template Field Migration Failed",
-    )
+def run_heavy_migrations(from_date):
+    try:
+        update_migration_progress(1, "Populating Master Child Table Mapping Records...")
+        migrate_master_child_tables(["Item", "Customer", "Supplier"])
 
-    # migrate_doctype_fields(
-    #     "Stock Ledger Entry",
-    #     {
-    #         "custom_submitted_successfully": "sent_to_etims",
-    #         "custom_submission_tries": "etims_submission_attempts",
-    #         "custom_slade_id": "etims_id",
-    #     },
-    #     "eTims Stock Ledger Entry Field Migration Failed",
-    # )
+        update_migration_progress(20, "Re-mapping Master Target ID Configurations...")
+        reconcile_master_id_mappings()
 
-    # migrate_doctype_fields(
-    #     "Sales Invoice",
-    #     {
-    #         "custom_successfully_submitted": "sent_to_etims",
-    #         "custom_slade_id": "etims_id",
-    #         "custom_qr_code_url": "etims_qr_code_url",
-    #         "custom_submission_attempts": "etims_submission_attempts",
-    #         "custom_qr_code": "etims_qr_image",
-    #     },
-    #     "eTims Sales Invoice Field Migration Failed",
-    # )
+        migrate_doctype_fields(
+            "Item",
+            {
+                "custom_prevent_etims_registration": "etims_prevent_etims_registration",
+                "custom_submission_tries": "etims_submission_tries",
+                "custom_taxation_type": "etims_taxation_type",
+                "custom_taxation_type_name": "etims_taxation_type_name",
+                "custom_item_classification": "etims_item_classification",
+                "custom_item_classification_code": "etims_item_classification_code",
+                "custom_etims_country_of_origin": "etims_country_of_origin",
+                "custom_etims_country_of_origin_code": "etims_country_of_origin_code",
+                "custom_packaging_unit": "etims_packaging_unit",
+                "custom_unit_of_quantity_code": "etims_unit_of_quantity_code",
+                "custom_unit_of_quantity": "etims_unit_of_quantity",
+                "custom_packaging_unit_code": "etims_packaging_unit_code",
+                "custom_item_type": "etims_item_type",
+                "custom_product_type": "etims_product_type",
+                "custom_item_type_name": "etims_item_type_name",
+                "custom_product_type_name": "etims_product_type_name",
+            },
+            "eTims Item Field Migration Failed",
+            start_perc=25,
+            end_perc=35,
+            main_criterion_field="custom_item_classification_code",
+        )
 
-    # migrate_doctype_fields(
-    #     "Sales Invoice Item",
-    #     {
-    #         "custom_tax_amount": "etims_tax_amount",
-    #         "custom_base_tax_amount": "etims_base_tax_amount",
-    #         "custom_tax_rate": "etims_tax_rate",
-    #     },
-    #     "eTims Sales Invoice Item Field Migration Failed",
-    # )
+        migrate_doctype_fields(
+            "Item Group",
+            {
+                "custom_prevent_etims_registration": "etims_prevent_etims_registration",
+                "custom_taxation_type": "etims_taxation_type",
+                "custom_taxation_type_name": "etims_taxation_type_name",
+                "custom_item_classification": "etims_item_classification",
+                "custom_item_classification_code": "etims_item_classification_code",
+                "custom_etims_country_of_origin": "etims_country_of_origin",
+                "custom_etims_country_of_origin_code": "etims_country_of_origin_code",
+                "custom_packaging_unit": "etims_packaging_unit",
+                "custom_unit_of_quantity_code": "etims_unit_of_quantity_code",
+                "custom_unit_of_quantity": "etims_unit_of_quantity",
+                "custom_packaging_unit_code": "etims_packaging_unit_code",
+                "custom_item_type": "etims_item_type",
+                "custom_product_type": "etims_product_type",
+                "custom_item_type_name": "etims_item_type_name",
+                "custom_product_type_name": "etims_product_type_name",
+            },
+            "eTims Item Group Field Migration Failed",
+            start_perc=35,
+            end_perc=45,
+            main_criterion_field="custom_item_classification_code",
+        )
 
-    migrate_doctype_fields(
-        "Customer",
-        {
-            "custom_prevent_etims_registration": "etims_prevent_etims_registration",
-        },
-        "eTims Customer Field Migration Failed",
-    )
+        update_migration_progress(46, "Processing Item Tax Templates...")
+        migrate_doctype_fields(
+            "Item Tax Template",
+            {
+                "custom_etims_taxation_type": "etims_taxation_type",
+            },
+            "eTims Item Tax Template Field Migration Failed",
+            start_perc=46,
+            end_perc=48,
+            main_criterion_field="custom_etims_taxation_type",
+        )
 
-    # generate_invoice_verification_urls()
-    set_etims_submission_modes()
+        update_migration_progress(49, "Processing Sales Taxes Templates...")
+        migrate_doctype_fields(
+            "Sales Taxes and Charges Template",
+            {
+                "custom_etims_taxation_type": "etims_taxation_type",
+            },
+            "eTims Sales Taxes and Charges Template Field Migration Failed",
+            start_perc=49,
+            end_perc=52,
+            main_criterion_field="custom_etims_taxation_type",
+        )
+
+        update_migration_progress(53, "Processing Customer Master Fields...")
+        migrate_doctype_fields(
+            "Customer",
+            {
+                "custom_prevent_etims_registration": "etims_prevent_etims_registration",
+            },
+            "eTims Customer Field Migration Failed",
+            start_perc=53,
+            end_perc=60,
+            main_criterion_field="custom_prevent_etims_registration",
+        )
+
+        migrate_doctype_fields_batched(
+            "Stock Ledger Entry",
+            {
+                "custom_submitted_successfully": "sent_to_etims",
+                "custom_submission_tries": "etims_submission_attempts",
+                "custom_slade_id": "etims_id",
+            },
+            "eTims Stock Ledger Entry Field Migration Failed",
+            60,
+            75,
+            from_date=from_date,
+            date_field="posting_date",
+            main_criterion_field="custom_slade_id",
+        )
+
+        migrate_doctype_fields_batched(
+            "Sales Invoice",
+            {
+                "custom_successfully_submitted": "sent_to_etims",
+                "custom_slade_id": "etims_id",
+                "custom_qr_code_url": "etims_qr_code_url",
+                "custom_submission_attempts": "etims_submission_attempts",
+                "custom_qr_code": "etims_qr_image",
+            },
+            "eTims Sales Invoice Field Migration Failed",
+            75,
+            90,
+            from_date=from_date,
+            date_field="posting_date",
+            main_criterion_field="custom_slade_id",
+        )
+
+        migrate_doctype_fields_batched(
+            "Sales Invoice Item",
+            {
+                "custom_tax_amount": "etims_tax_amount",
+                "custom_base_tax_amount": "etims_base_tax_amount",
+                "custom_tax_rate": "etims_tax_rate",
+            },
+            "eTims Sales Invoice Item Field Migration Failed",
+            90,
+            95,
+            from_date=from_date,
+            date_field="creation",
+            main_criterion_field="custom_tax_rate",
+        )
+
+        generate_invoice_verification_urls(from_date)
+
+        update_migration_progress(98, "Finishing up submission rules settings...")
+        set_etims_submission_modes()
+
+        update_migration_progress(100, "Migration successfully finished!")
+
+    except Exception:
+        frappe.db.rollback()
+        update_migration_progress(0, "Migration stopped due to errors.")
+
+
+def reconcile_master_id_mappings():
+    if not frappe.db.exists("DocType", "eTims ID Mapping"):
+        return
+
+    doctypes = ["Customer", "Item", "Supplier"]
+    for d_idx, doctype in enumerate(doctypes, start=1):
+        if not frappe.db.exists("DocType", doctype):
+            continue
+
+        records = frappe.get_all(doctype, fields=["name"], limit_page_length=0)
+        total_records = len(records)
+        if not total_records:
+            continue
+
+        for idx, row in enumerate(records, start=1):
+            if idx % 20 == 0 or idx == total_records:
+                current_perc = int(((d_idx - 1) / len(doctypes)) * 15) + 20
+                update_migration_progress(
+                    current_perc,
+                    f"Cross-referencing {doctype} configuration structures ({idx}/{total_records})...",
+                )
+
+            try:
+                doc = frappe.get_doc(doctype, row.name)
+                setup_mappings = doc.get("etims_setup_mapping") or []
+
+                existing_global_entries = frappe.get_all(
+                    "eTims ID Mapping",
+                    filters={"parent": doc.name, "parenttype": doctype},
+                    fields=["name", "etims_id", "disabled", "setup_docname"],
+                )
+
+                seen_pairs = set()
+                for entry in existing_global_entries:
+                    pair_key = (entry.setup_docname, entry.etims_id)
+                    if pair_key in seen_pairs:
+                        frappe.delete_doc(
+                            "eTims ID Mapping", entry.name, ignore_permissions=True
+                        )
+                        continue
+                    seen_pairs.add(pair_key)
+
+                existing_global_entries = frappe.get_all(
+                    "eTims ID Mapping",
+                    filters={"parent": doc.name, "parenttype": doctype},
+                    fields=["name", "etims_id", "disabled", "setup_docname"],
+                )
+
+                if not setup_mappings:
+                    for entry in existing_global_entries:
+                        if not entry.disabled:
+                            frappe.db.set_value(
+                                "eTims ID Mapping",
+                                entry.name,
+                                "disabled",
+                                1,
+                                update_modified=False,
+                            )
+                    continue
+
+                for child in setup_mappings:
+                    child_setup = getattr(child, "etims_setup", None) or getattr(
+                        child, "setup_docname", None
+                    )
+                    child_id = getattr(child, "etims_id", None) or getattr(
+                        child, "custom_slade_id", None
+                    )
+                    child_active = not getattr(child, "disabled", 0) and getattr(
+                        child, "registered", 1
+                    )
+
+                    if not child_setup or not child_id:
+                        continue
+
+                    match_found = False
+                    for entry in existing_global_entries:
+                        if (
+                            entry.setup_docname == child_setup
+                            and entry.etims_id == child_id
+                        ):
+                            match_found = True
+                            target_disabled = 0 if child_active else 1
+                            if entry.disabled != target_disabled:
+                                frappe.db.set_value(
+                                    "eTims ID Mapping",
+                                    entry.name,
+                                    "disabled",
+                                    target_disabled,
+                                    update_modified=False,
+                                )
+                            break
+
+                    if not match_found:
+                        new_mapping = frappe.get_doc(
+                            {
+                                "doctype": "eTims ID Mapping",
+                                "setup_doctype": "Navari KRA eTims Settings",
+                                "setup_docname": child_setup,
+                                "etims_id": child_id,
+                                "disabled": 0 if child_active else 1,
+                                "parent": doc.name,
+                                "parenttype": doctype,
+                                "parentfield": "etims_id_mapping",
+                            }
+                        )
+                        new_mapping.insert(ignore_permissions=True)
+
+                for entry in existing_global_entries:
+                    child_match = False
+                    for child in setup_mappings:
+                        child_setup = getattr(child, "etims_setup", None) or getattr(
+                            child, "setup_docname", None
+                        )
+                        child_id = getattr(child, "etims_id", None) or getattr(
+                            child, "custom_slade_id", None
+                        )
+                        if (
+                            child_setup == entry.setup_docname
+                            and child_id == entry.etims_id
+                        ):
+                            child_match = True
+                            break
+
+                    if not child_match and not entry.disabled:
+                        frappe.db.set_value(
+                            "eTims ID Mapping",
+                            entry.name,
+                            "disabled",
+                            1,
+                            update_modified=False,
+                        )
+
+                if idx % 100 == 0:
+                    frappe.db.commit()
+
+            except Exception:
+                frappe.db.rollback()
+                frappe.log_error(
+                    title=f"Mapping Synchronization Broken for {doctype} {row.name}",
+                    message=frappe.get_traceback(),
+                )
+                frappe.db.commit()
+
+        frappe.db.commit()
+
+
+def migrate_master_child_tables(doctypes):
+    for d_idx, doctype in enumerate(doctypes, start=1):
+        if not frappe.db.exists("DocType", doctype):
+            continue
+
+        meta = frappe.get_meta(doctype)
+        if not meta.has_field("etims_setup_mapping"):
+            continue
+
+        records = frappe.get_all(
+            doctype,
+            filters={"custom_item_classification_code": ("is", "set")}
+            if doctype == "Item"
+            else {},
+            fields=["name"],
+            limit_page_length=0,
+        )
+        total_records = len(records)
+        if not total_records:
+            continue
+
+        for idx, row in enumerate(records, start=1):
+            if idx % 10 == 0 or idx == total_records:
+                current_perc = int(((d_idx - 1) / len(doctypes)) * 15) + 1
+                update_migration_progress(
+                    current_perc,
+                    f"Mapping {doctype} setups ({idx}/{total_records})...",
+                )
+
+            try:
+                doc = frappe.get_doc(doctype, row.name)
+                has_changes = False
+
+                for child in doc.get("etims_setup_mapping"):
+                    if (
+                        hasattr(child, "custom_slade_id")
+                        and child.custom_slade_id
+                        and not child.etims_id
+                    ):
+                        child.etims_id = child.custom_slade_id
+                        has_changes = True
+
+                    if (
+                        hasattr(child, "custom_submitted_successfully")
+                        and child.custom_submitted_successfully
+                        and not child.registered
+                    ):
+                        child.registered = child.custom_submitted_successfully
+                        has_changes = True
+
+                if has_changes:
+                    doc.save(ignore_permissions=True, ignore_version=True)
+
+                if idx % 100 == 0:
+                    frappe.db.commit()
+
+            except Exception:
+                frappe.db.rollback()
+                frappe.log_error(
+                    title=f"eTims Setup Mapping Child Table Migration Failed for {doctype}",
+                    message=frappe.get_traceback(),
+                )
+                frappe.db.commit()
+
+        frappe.db.commit()
 
 
 def get_valid_field_map(doctype, field_map):
@@ -124,21 +423,110 @@ def get_valid_field_map(doctype, field_map):
     return valid_map
 
 
-def migrate_doctype_fields(doctype, field_map, error_title):
+def migrate_doctype_fields(
+    doctype, field_map, error_title, start_perc, end_perc, main_criterion_field=None
+):
     valid_field_map = get_valid_field_map(doctype, field_map)
     if not valid_field_map:
         return
 
+    filters = {}
+    if main_criterion_field and frappe.db.has_column(doctype, main_criterion_field):
+        filters[main_criterion_field] = ("is", "set")
+
     records = frappe.get_all(
         doctype,
+        filters=filters,
         fields=["name"] + list(valid_field_map.keys()),
         limit_page_length=0,
     )
+    total_records = len(records)
+    if not total_records:
+        return
+
+    perc_range = end_perc - start_perc
 
     for idx, record in enumerate(records, start=1):
+        if idx % 25 == 0 or idx == total_records:
+            progress_perc = start_perc + int((idx / total_records) * perc_range)
+            update_migration_progress(
+                progress_perc,
+                f"Processing {doctype} metadata registers ({idx}/{total_records})...",
+            )
+
         try:
             update_values = {}
+            for src, target in valid_field_map.items():
+                value = getattr(record, src, None)
+                if value is not None:
+                    update_values[target] = value
 
+            if not update_values:
+                continue
+
+            frappe.db.set_value(
+                doctype,
+                record.name,
+                update_values,
+                update_modified=False,
+            )
+
+            if idx % 500 == 0:
+                frappe.db.commit()
+
+        except Exception:
+            frappe.db.rollback()
+            frappe.log_error(
+                title=error_title,
+                message=frappe.get_traceback(),
+            )
+            frappe.db.commit()
+
+    frappe.db.commit()
+
+
+def migrate_doctype_fields_batched(
+    doctype,
+    field_map,
+    error_title,
+    start_perc,
+    end_perc,
+    from_date=None,
+    date_field="posting_date",
+    main_criterion_field=None,
+):
+    valid_field_map = get_valid_field_map(doctype, field_map)
+    if not valid_field_map:
+        return
+
+    filters = {}
+    if from_date and frappe.db.has_column(doctype, date_field):
+        filters[date_field] = (">=", from_date)
+    if main_criterion_field and frappe.db.has_column(doctype, main_criterion_field):
+        filters[main_criterion_field] = ("is", "set")
+
+    records = frappe.get_all(
+        doctype,
+        filters=filters,
+        fields=["name"] + list(valid_field_map.keys()),
+        limit_page_length=0,
+    )
+    total_records = len(records)
+    if not total_records:
+        return
+
+    perc_range = end_perc - start_perc
+
+    for idx, record in enumerate(records, start=1):
+        if idx % 50 == 0 or idx == total_records:
+            progress_perc = start_perc + int((idx / total_records) * perc_range)
+            update_migration_progress(
+                progress_perc,
+                f"Updating {doctype} rows ({idx}/{total_records})...",
+            )
+
+        try:
+            update_values = {}
             for src, target in valid_field_map.items():
                 value = getattr(record, src, None)
                 if value is not None:
@@ -168,77 +556,33 @@ def migrate_doctype_fields(doctype, field_map, error_title):
     frappe.db.commit()
 
 
-def migrate_etims_id_mapping():
-    if not frappe.db.exists(
-        "DocType", "eTims Slade360 ID Mapping"
-    ) or not frappe.db.exists("DocType", "eTims ID Mapping"):
-        return
+def generate_invoice_verification_urls(from_date=None):
+    filters = {
+        "docstatus": 1,
+        "etims_verification_url": ("is", None),
+        "etims_id": ("is", "set"),
+    }
+    if from_date:
+        filters["posting_date"] = (">=", from_date)
 
-    old_rows = frappe.get_all(
-        "eTims Slade360 ID Mapping",
-        fields=[
-            "name",
-            "parent",
-            "parenttype",
-            "etims_setup",
-            "slade360_id",
-            "is_active",
-        ],
-        limit_page_length=0,
-    )
-
-    for idx, row in enumerate(old_rows, start=1):
-        try:
-            exists = frappe.db.exists(
-                "eTims ID Mapping",
-                {
-                    "setup_doctype": "Navari KRA eTims Settings",
-                    "setup_docname": row.etims_setup,
-                    "etims_id": row.slade360_id,
-                },
-            )
-
-            if exists:
-                continue
-
-            doc = frappe.get_doc(
-                {
-                    "doctype": "eTims ID Mapping",
-                    "setup_doctype": "Navari KRA eTims Settings",
-                    "setup_docname": row.etims_setup,
-                    "etims_id": row.slade360_id,
-                    "disabled": 0 if row.is_active else 1,
-                    "parent": row.parent,
-                    "parenttype": row.parenttype,
-                    "parentfield": "etims_id_mapping",
-                }
-            )
-
-            doc.insert(ignore_permissions=True)
-
-            if idx % 1000 == 0:
-                frappe.db.commit()
-
-        except Exception:
-            frappe.db.rollback()
-            frappe.log_error(
-                title="eTims ID Mapping Migration Failed",
-                message=frappe.get_traceback(),
-            )
-            frappe.db.commit()
-
-    frappe.db.commit()
-
-
-def generate_invoice_verification_urls():
     invoices = frappe.get_all(
         "Sales Invoice",
-        filters={"docstatus": 1, "etims_verification_url": ("is", None)},
+        filters=filters,
         fields=["name"],
         limit_page_length=0,
     )
+    total_records = len(invoices)
+    if not total_records:
+        return
 
     for idx, invoice in enumerate(invoices, start=1):
+        if idx % 50 == 0 or idx == total_records:
+            progress_perc = 95 + int((idx / total_records) * 3)
+            update_migration_progress(
+                progress_perc,
+                f"Compiling verification URLs ({idx}/{total_records})...",
+            )
+
         try:
             doc = frappe.get_doc("Sales Invoice", invoice.name)
             url = build_verification_url(doc)
@@ -251,7 +595,7 @@ def generate_invoice_verification_urls():
                     update_modified=False,
                 )
 
-            if idx % 1000 == 0:
+            if idx % 500 == 0:
                 frappe.db.commit()
 
         except Exception:

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/migrate_csf_ke_data.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/patches/migrate_csf_ke_data.py
@@ -48,7 +48,6 @@ def update_migration_progress(percent, description):
 def run_heavy_migrations(from_date):
     try:
         update_migration_progress(1, "Populating Master Child Table Mapping Records...")
-        migrate_master_child_tables(["Item", "Customer", "Supplier"])
 
         update_migration_progress(20, "Re-mapping Master Target ID Configurations...")
         reconcile_master_id_mappings()
@@ -260,15 +259,11 @@ def reconcile_master_id_mappings():
                     continue
 
                 for child in setup_mappings:
-                    child_setup = getattr(child, "etims_setup", None) or getattr(
-                        child, "setup_docname", None
+                    child_setup = getattr(child, "etims_setup", None)
+                    child_id = getattr(child, "slade360_id", None) or getattr(
+                        child, "etims_id", None
                     )
-                    child_id = getattr(child, "etims_id", None) or getattr(
-                        child, "custom_slade_id", None
-                    )
-                    child_active = not getattr(child, "disabled", 0) and getattr(
-                        child, "registered", 1
-                    )
+                    child_active = getattr(child, "is_active", 1)
 
                     if not child_setup or not child_id:
                         continue
@@ -309,11 +304,9 @@ def reconcile_master_id_mappings():
                 for entry in existing_global_entries:
                     child_match = False
                     for child in setup_mappings:
-                        child_setup = getattr(child, "etims_setup", None) or getattr(
-                            child, "setup_docname", None
-                        )
-                        child_id = getattr(child, "etims_id", None) or getattr(
-                            child, "custom_slade_id", None
+                        child_setup = getattr(child, "etims_setup", None)
+                        child_id = getattr(child, "slade360_id", None) or getattr(
+                            child, "etims_id", None
                         )
                         if (
                             child_setup == entry.setup_docname
@@ -338,73 +331,6 @@ def reconcile_master_id_mappings():
                 frappe.db.rollback()
                 frappe.log_error(
                     title=f"Mapping Synchronization Broken for {doctype} {row.name}",
-                    message=frappe.get_traceback(),
-                )
-                frappe.db.commit()
-
-        frappe.db.commit()
-
-
-def migrate_master_child_tables(doctypes):
-    for d_idx, doctype in enumerate(doctypes, start=1):
-        if not frappe.db.exists("DocType", doctype):
-            continue
-
-        meta = frappe.get_meta(doctype)
-        if not meta.has_field("etims_setup_mapping"):
-            continue
-
-        records = frappe.get_all(
-            doctype,
-            filters={"custom_item_classification_code": ("is", "set")}
-            if doctype == "Item"
-            else {},
-            fields=["name"],
-            limit_page_length=0,
-        )
-        total_records = len(records)
-        if not total_records:
-            continue
-
-        for idx, row in enumerate(records, start=1):
-            if idx % 10 == 0 or idx == total_records:
-                current_perc = int(((d_idx - 1) / len(doctypes)) * 15) + 1
-                update_migration_progress(
-                    current_perc,
-                    f"Mapping {doctype} setups ({idx}/{total_records})...",
-                )
-
-            try:
-                doc = frappe.get_doc(doctype, row.name)
-                has_changes = False
-
-                for child in doc.get("etims_setup_mapping"):
-                    if (
-                        hasattr(child, "custom_slade_id")
-                        and child.custom_slade_id
-                        and not child.etims_id
-                    ):
-                        child.etims_id = child.custom_slade_id
-                        has_changes = True
-
-                    if (
-                        hasattr(child, "custom_submitted_successfully")
-                        and child.custom_submitted_successfully
-                        and not child.registered
-                    ):
-                        child.registered = child.custom_submitted_successfully
-                        has_changes = True
-
-                if has_changes:
-                    doc.save(ignore_permissions=True, ignore_version=True)
-
-                if idx % 100 == 0:
-                    frappe.db.commit()
-
-            except Exception:
-                frappe.db.rollback()
-                frappe.log_error(
-                    title=f"eTims Setup Mapping Child Table Migration Failed for {doctype}",
                     message=frappe.get_traceback(),
                 )
                 frappe.db.commit()
@@ -559,7 +485,6 @@ def migrate_doctype_fields_batched(
 def generate_invoice_verification_urls(from_date=None):
     filters = {
         "docstatus": 1,
-        "etims_verification_url": ("is", None),
         "etims_id": ("is", "set"),
     }
     if from_date:

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -2423,7 +2423,7 @@ def check_hanging_custom_fields():
     hanging_fields = frappe.get_all(
         "Custom Field",
         filters={
-            "dt": ["in", doctypes],
+            # "dt": ["in", doctypes],
             "module": "Kenya Compliance Via Slade",
         },
         fields=["name", "dt", "fieldname", "label"],

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -2402,8 +2402,18 @@ def build_verification_url(doc) -> str:
     creation = get_datetime(doc.creation) if doc.creation else None
 
     key = creation.strftime("%Y%m%d%H%M%S%f") if creation else ""
+    base_url = frappe.utils.get_url()
 
-    return f"/invoice-verification?id={quote(str(doc.name))}&key={quote(key)}"
+    parsed_url = urlparse(base_url)
+
+    if parsed_url.hostname:
+        if not (
+            parsed_url.hostname == "localhost"
+            or parsed_url.hostname.replace(".", "").isdigit()
+        ):
+            base_url = f"{parsed_url.scheme}://{parsed_url.hostname}"
+
+    return f"{base_url}/invoice-verification?id={quote(str(doc.name))}&key={quote(key)}"
 
 
 @frappe.whitelist()

--- a/kenya_compliance_via_slade/patches.txt
+++ b/kenya_compliance_via_slade/patches.txt
@@ -6,5 +6,5 @@ kenya_compliance_via_slade.kenya_compliance_via_slade.patches.drop_custom_fields
 kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_to_multi_company # 153/07/25 
 kenya_compliance_via_slade.kenya_compliance_via_slade.patches.set_etims_mappings_active # 13/03/26
 kenya_compliance_via_slade.kenya_compliance_via_slade.patches.set_taxation_type_codes # 22/03/26
-kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_csf_ke_data # 13/06/2026
+# kenya_compliance_via_slade.kenya_compliance_via_slade.patches.migrate_csf_ke_data # 13/06/2026
 kenya_compliance_via_slade.kenya_compliance_via_slade.patches.purge_invalid_etims_ledger_records # 03/06/2026


### PR DESCRIPTION
This pull request introduces significant improvements to how company context is handled throughout the Kenya Compliance via Slade integration, especially in the processing and synchronization of eTIMS sales invoices and credit notes. The changes ensure that company information is consistently passed, stored, and used in both API calls and background task handlers. Additionally, error handling for batch processing of eTIMS entries has been enhanced, with new mechanisms to log and save errors for further analysis.

Key changes include:

**Company Context Propagation and Handling:**
* Added a `company` property to the `APIBuilder` class, including getter and setter methods, and ensured that this property is passed through all relevant API calls, response handlers, and background tasks. This allows the system to correctly associate requests and responses with the appropriate company. [[1]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R37) [[2]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R75-R83) [[3]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R347-R355) [[4]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R585) [[5]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R598) [[6]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R613) [[7]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R653) [[8]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R669) [[9]](diffhunk://#diff-baf88638d25432eb75197a93f580e7f47b6567a788616e42f496196f2b3edbb5R714) [[10]](diffhunk://#diff-8c4e4fc3316f9052a6b6ad198dd9e74a368ba204505e0bd75c7ec068234e7237R122) [[11]](diffhunk://#diff-8c4e4fc3316f9052a6b6ad198dd9e74a368ba204505e0bd75c7ec068234e7237R185) [[12]](diffhunk://#diff-8c4e4fc3316f9052a6b6ad198dd9e74a368ba204505e0bd75c7ec068234e7237R222) [[13]](diffhunk://#diff-07fa816e70125704befdf104e9a2dc83383e393842f04b759ae1ad8ea85f4633R322)

* Updated background tasks to determine the company either from the document or from organization mappings, and to pass this company information into fetch and handler functions for both sales invoices and credit notes. [[1]](diffhunk://#diff-323951094c926ff6a103f94551ce30619827d31f420fd4801029d928b5319bcaR678-R716) [[2]](diffhunk://#diff-323951094c926ff6a103f94551ce30619827d31f420fd4801029d928b5319bcaR731) [[3]](diffhunk://#diff-323951094c926ff6a103f94551ce30619827d31f420fd4801029d928b5319bcaR740) [[4]](diffhunk://#diff-323951094c926ff6a103f94551ce30619827d31f420fd4801029d928b5319bcaR759)

**Enhanced eTIMS Response Handling and Error Logging:**
* Refactored `fetch_etims_sales_invoices_on_success` and `fetch_etims_credit_notes_on_success` to process entries with company context, detect duplicates within a batch, and collect detailed error information. Errors are now saved in a new `eTIMS Sync Error Log` document for better traceability. [[1]](diffhunk://#diff-3840b8bb1c5ee6a50168c1eb22d27b1d0bed84a1182135130f5f0b1300cbf9f9R741-R910) [[2]](diffhunk://#diff-3840b8bb1c5ee6a50168c1eb22d27b1d0bed84a1182135130f5f0b1300cbf9f9R943)

* Improved the `process_single_etims_entry` function to accept and use the company parameter, and added handling for unique constraint violations to avoid duplicate entries. [[1]](diffhunk://#diff-3840b8bb1c5ee6a50168c1eb22d27b1d0bed84a1182135130f5f0b1300cbf9f9R943) [[2]](diffhunk://#diff-3840b8bb1c5ee6a50168c1eb22d27b1d0bed84a1182135130f5f0b1300cbf9f9R997) [[3]](diffhunk://#diff-3840b8bb1c5ee6a50168c1eb22d27b1d0bed84a1182135130f5f0b1300cbf9f9R1013-R1019)

* Removed obsolete versions of the invoice and credit note success handlers, consolidating logic into the new, more robust implementations.

**Minor Improvements:**
* Cleaned up error handling comments in the front-end JavaScript for Navari KRA eTims Settings. [[1]](diffhunk://#diff-767ea2f3c4805c5aee77a3820f1ecd7a679c64ee3ba264c25d23f59a7a5dd70bL90) [[2]](diffhunk://#diff-767ea2f3c4805c5aee77a3820f1ecd7a679c64ee3ba264c25d23f59a7a5dd70bL138)