### PR TITLE
feat: add QR code regeneration for individual and bulk Sales Invoices

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
@@ -595,6 +595,16 @@ function addCustomButtons(frm, activeSetting, summaryData) {
     );
   }
 
+  if (frm.doc.etims_qr_image) {
+    frm.add_custom_button(
+      __("Regenerate QR Code"),
+      function () {
+        regenerateQRCode(frm, activeSetting);
+      },
+      __("eTims Actions"),
+    );
+  }
+
   frm.add_custom_button(
     __("Sync or Check Status"),
     function () {
@@ -642,6 +652,108 @@ function addCustomButtons(frm, activeSetting, summaryData) {
       __("eTims Actions"),
     );
   }
+}
+
+async function regenerateQRCode(frm, activeSetting) {
+  frappe.confirm(
+    __("Are you sure you want to regenerate the QR code for this invoice?"),
+    function () {
+      frappe.call({
+        method:
+          "kenya_compliance_via_slade.kenya_compliance_via_slade.overrides.server.sales_invoice.regenerate_qr_code",
+        args: {
+          names: [frm.doc.name],
+        },
+        freeze: true,
+        freeze_message: "Regenerating QR Code...",
+        callback: function (response) {
+          if (response.message && response.message.results) {
+            const result = response.message;
+            const invoiceResult = result.results[0];
+
+            if (invoiceResult.status === "success") {
+              frappe.msgprint({
+                title: __("✅ QR Code Regenerated Successfully"),
+                indicator: "green",
+                message: `
+                  <div style="margin: 10px 0; padding: 15px; background: #f0fdf4; border-radius: 6px; border: 1px solid #bbf7d0;">
+                    <div style="font-size: 15px; font-weight: 600; color: #166534; margin-bottom: 8px;">
+                      ${frappe.utils.escape_html(frm.doc.name)}
+                    </div>
+                    <div style="color: #14532d;">
+                      <strong>Status:</strong> ${invoiceResult.message}
+                    </div>
+                    <div style="margin-top: 5px; color: #166534;">
+                      <span style="display: inline-block; padding: 3px 10px; background: #d1fae5; border-radius: 4px; font-size: 12px;">
+                        ${__("QR Code Updated")}
+                      </span>
+                    </div>
+                  </div>
+                `,
+              });
+            } else if (invoiceResult.status === "skipped") {
+              frappe.msgprint({
+                title: __("⏭️ QR Code Regeneration Skipped"),
+                indicator: "orange",
+                message: `
+                  <div style="margin: 10px 0; padding: 15px; background: #fffbeb; border-radius: 6px; border: 1px solid #fde68a;">
+                    <div style="font-size: 15px; font-weight: 600; color: #92400e; margin-bottom: 8px;">
+                      ${frappe.utils.escape_html(frm.doc.name)}
+                    </div>
+                    <div style="color: #78350f;">
+                      <strong>Reason:</strong> ${invoiceResult.message}
+                    </div>
+                    <div style="margin-top: 8px; padding: 8px 12px; background: #fef3c7; border-radius: 4px; font-size: 13px;">
+                      ${__("No verification URL found. Please ensure the invoice has been submitted to eTIMS first.")}
+                    </div>
+                  </div>
+                `,
+              });
+            } else if (invoiceResult.status === "error") {
+              frappe.msgprint({
+                title: __("❌ QR Code Regeneration Failed"),
+                indicator: "red",
+                message: `
+                  <div style="margin: 10px 0; padding: 15px; background: #fef2f2; border-radius: 6px; border: 1px solid #fecaca;">
+                    <div style="font-size: 15px; font-weight: 600; color: #991b1b; margin-bottom: 8px;">
+                      ${frappe.utils.escape_html(frm.doc.name)}
+                    </div>
+                    <div style="color: #7f1d1d;">
+                      <strong>Error:</strong> ${invoiceResult.message}
+                    </div>
+                    <div style="margin-top: 8px; padding: 8px 12px; background: #fee2e2; border-radius: 4px; font-size: 13px;">
+                      ${__("Please check the logs or contact support if the issue persists.")}
+                    </div>
+                  </div>
+                `,
+              });
+            }
+          }
+          frm.reload_doc();
+        },
+        error: function (err) {
+          frappe.msgprint({
+            title: __("❌ QR Code Regeneration Failed"),
+            indicator: "red",
+            message: `
+              <div style="margin: 10px 0; padding: 15px; background: #fef2f2; border-radius: 6px; border: 1px solid #fecaca;">
+                <div style="font-size: 15px; font-weight: 600; color: #991b1b; margin-bottom: 8px;">
+                  ${frappe.utils.escape_html(frm.doc.name)}
+                </div>
+                <div style="color: #7f1d1d;">
+                  <strong>Error:</strong> ${err.message || err}
+                </div>
+                <div style="margin-top: 8px; padding: 8px 12px; background: #fee2e2; border-radius: 4px; font-size: 13px;">
+                  ${__("An unexpected error occurred. Please try again or contact support.")}
+                </div>
+              </div>
+            `,
+          });
+          console.error("QR Code regeneration error:", err);
+        },
+      });
+    },
+  );
 }
 
 function showCorrectionDialog(frm, activeSetting, summaryData) {

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice_list.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice_list.js
@@ -19,19 +19,59 @@ frappe.listview_settings[doctypeName].onload = async function (listview) {
 
   if (activeSetting?.length > 0) {
     listview.page.add_action_item(
-      __("Bulk Submit to eTims"),
+      __("Submit to eTims"),
       function () {
+        const checked_items = listview.get_checked_items();
+        if (checked_items.length === 0) {
+          frappe.msgprint(__("Please select at least one invoice."));
+          return;
+        }
+
         showSettingsModalAndExecute(
-          "Bulk Submit to eTims",
+          "Submit to eTims",
           activeSetting,
           (settings_name) => ({
             method: "bulk_submit_sales_invoices",
             args: {
-              docs_list: listview.get_checked_items().map((item) => item.name),
+              docs_list: checked_items.map((item) => item.name),
               settings_name,
             },
-            success_msg: "Bulk submission to eTims queued.",
+            success_msg: "Submission to eTims queued.",
           }),
+        );
+      },
+      __("eTims Actions"),
+    );
+
+    listview.page.add_action_item(
+      __("Regenerate eTims QR Codes"),
+      function () {
+        const checked_items = listview.get_checked_items();
+        if (checked_items.length === 0) {
+          frappe.msgprint(__("Please select at least one invoice."));
+          return;
+        }
+
+        const invoiceNames = checked_items.map((item) => item.name);
+
+        frappe.confirm(
+          __("Are you sure you want to regenerate QR codes for {0} invoices?", [
+            invoiceNames.length,
+          ]),
+          function () {
+            showSettingsModalAndExecute(
+              "Regenerate QR Codes",
+              activeSetting,
+              (settings_name) => ({
+                method: "regenerate_qr_code",
+                args: {
+                  names: invoiceNames,
+                  settings_name: settings_name,
+                },
+                success_msg: `QR Code regeneration for ${invoiceNames.length} invoices`,
+              }),
+            );
+          },
         );
       },
       __("eTims Actions"),
@@ -89,17 +129,113 @@ function executeWithSingleOrDialog(settings, actionFn, buildDialog) {
 }
 
 function executeEtimsAction(method, args, successMsg) {
+  let methodPath;
+
+  if (method === "regenerate_qr_code") {
+    methodPath = `kenya_compliance_via_slade.kenya_compliance_via_slade.overrides.server.sales_invoice.${method}`;
+  } else {
+    methodPath = `kenya_compliance_via_slade.kenya_compliance_via_slade.apis.apis.${method}`;
+  }
+
   frappe.call({
-    method: `kenya_compliance_via_slade.kenya_compliance_via_slade.apis.apis.${method}`,
+    method: methodPath,
     args,
     freeze: true,
     freeze_message: __("Processing..."),
-    callback: () => {
-      frappe.msgprint(__(successMsg));
+    callback: (response) => {
+      if (response.message && response.message.results) {
+        const result = response.message;
+
+        const grouped = {
+          success: result.results.filter((r) => r.status === "success"),
+          error: result.results.filter((r) => r.status === "error"),
+          skipped: result.results.filter((r) => r.status === "skipped"),
+        };
+
+        let summaryHtml = `
+          <div style="margin: 10px 0;">
+            <strong>Total Processed:</strong> ${result.total}<br>
+            <strong>✅ Success:</strong> ${grouped.success.length}<br>
+            <strong>⏭️ Skipped:</strong> ${grouped.skipped.length}<br>
+            <strong>❌ Errors:</strong> ${grouped.error.length}
+          </div>
+        `;
+
+        if (grouped.success.length > 0) {
+          const successList = grouped.success
+            .map((r) => `<li>${r.invoice}</li>`)
+            .join("");
+          summaryHtml += `
+            <div style="margin-top: 12px; padding: 10px; background: #f0fdf4; border-radius: 4px; border: 1px solid #bbf7d0;">
+              <strong style="color: #166534;">✅ Successful (${grouped.success.length}):</strong>
+              <ul style="margin: 5px 0 0 20px; padding: 0; list-style: disc;">
+                ${successList}
+              </ul>
+            </div>
+          `;
+        }
+
+        if (grouped.skipped.length > 0) {
+          const skippedDetails = grouped.skipped
+            .map((r) => `<li><strong>${r.invoice}</strong>: ${r.message}</li>`)
+            .join("");
+          summaryHtml += `
+            <div style="margin-top: 12px; padding: 10px; background: #fffbeb; border-radius: 4px; border: 1px solid #fde68a;">
+              <strong style="color: #92400e;">⏭️ Skipped (${grouped.skipped.length}):</strong>
+              <ul style="margin: 5px 0 0 20px; padding: 0; list-style: disc;">
+                ${skippedDetails}
+              </ul>
+            </div>
+          `;
+        }
+
+        if (grouped.error.length > 0) {
+          const errorDetails = grouped.error
+            .map((r) => `<li><strong>${r.invoice}</strong>: ${r.message}</li>`)
+            .join("");
+          summaryHtml += `
+            <div style="margin-top: 12px; padding: 10px; background: #fef2f2; border-radius: 4px; border: 1px solid #fecaca;">
+              <strong style="color: #991b1b;">❌ Errors (${grouped.error.length}):</strong>
+              <ul style="margin: 5px 0 0 20px; padding: 0; list-style: disc;">
+                ${errorDetails}
+              </ul>
+            </div>
+          `;
+        }
+
+        let indicator = "green";
+        let title = __(successMsg);
+
+        if (grouped.error.length > 0) {
+          indicator = "red";
+          title = __(successMsg + " with Errors");
+        } else if (grouped.skipped.length > 0 && grouped.success.length === 0) {
+          indicator = "orange";
+          title = __(successMsg + " with Skips");
+        }
+
+        frappe.msgprint({
+          title: title,
+          indicator: indicator,
+          message: summaryHtml,
+        });
+
+        setTimeout(() => {
+          frappe.listview.refresh();
+        }, 2000);
+      } else {
+        frappe.msgprint(__(successMsg));
+      }
     },
     error: (err) => {
       console.error(err);
-      frappe.msgprint(__("An error occurred during the request."));
+      frappe.msgprint({
+        title: __("Error"),
+        indicator: "red",
+        message: __("An error occurred during the request: {0}", [
+          err.message || err,
+        ]),
+      });
     },
   });
 }

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/sales_invoice.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/sales_invoice.py
@@ -6,6 +6,8 @@ from frappe.utils import add_to_date, flt, getdate
 
 from ...utils import (
     apply_item_taxes_and_codes,
+    build_verification_url,
+    generate_and_attach_qr_code,
     get_settings,
 )
 from .shared_overrides import generic_invoices_on_submit_override
@@ -302,3 +304,65 @@ def _calculate_reconciliation_summary(
         "details": etims_data["details"],
         "sent_to_etims": invoice.sent_to_etims,
     }
+
+
+@frappe.whitelist()
+def regenerate_qr_code(names):
+    if isinstance(names, str):
+        try:
+            names = frappe.parse_json(names)
+        except:
+            names = [names]
+
+    if not isinstance(names, list):
+        names = [names]
+
+    if not names:
+        frappe.throw("No invoice names provided")
+
+    results = []
+    errors = []
+
+    for name in names:
+        try:
+            doc = frappe.get_doc("Sales Invoice", name)
+
+            etims_verification_url = build_verification_url(doc)
+
+            if etims_verification_url and doc.etims_qr_image:
+                doc.db_set(
+                    "etims_verification_url",
+                    etims_verification_url,
+                    update_modified=False,
+                )
+
+                etims_qr_image = generate_and_attach_qr_code(
+                    etims_verification_url, name, doc.doctype
+                )
+
+                doc.db_set("etims_qr_image", etims_qr_image, update_modified=False)
+
+                frappe.db.commit()
+
+                results.append(
+                    {
+                        "invoice": name,
+                        "status": "success",
+                        "message": "Verification URL and QR Code regenerated successfully",
+                    }
+                )
+            else:
+                results.append(
+                    {
+                        "invoice": name,
+                        "status": "skipped",
+                        "message": "Unable to build verification URL",
+                    }
+                )
+
+        except Exception as e:
+            frappe.db.rollback()
+            errors.append({"invoice": name, "error": str(e)})
+            results.append({"invoice": name, "status": "error", "message": str(e)})
+
+    return {"results": results, "total": len(results), "errors": len(errors)}


### PR DESCRIPTION
This pull request introduces new functionality for regenerating eTims QR codes for sales invoices, both individually and in bulk, along with enhanced user feedback and error handling. The changes span client-side UI enhancements and server-side logic to support QR code regeneration, as well as improved summary messaging for batch operations.

**New eTims QR Code Regeneration Features and Improved User Feedback:**

**Client-side enhancements:**
- Added a "Regenerate QR Code" button on the sales invoice form, which prompts the user for confirmation and then calls a new backend method to regenerate the QR code for the current invoice. The user receives detailed feedback on the outcome (success, skipped, or error) via styled messages. [[1]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8R598-R607) [[2]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8R657-R758)
- Added a "Regenerate eTims QR Codes" bulk action in the sales invoice list view, allowing users to select multiple invoices and regenerate their QR codes in one operation, with confirmation and summary reporting.

**Bulk operation improvements:**
- Enhanced the logic for executing eTims actions in bulk, including QR code regeneration, to display a detailed summary of results (successes, skips, errors) after processing, and improved error message formatting.

**Server-side logic:**
- Added the `regenerate_qr_code` backend method, which rebuilds the verification URL and regenerates/attaches the QR code for each specified invoice, handling errors gracefully and returning per-invoice results.
- Updated imports to include utilities required for QR code regeneration.