### PR TITLE
fix: update required app dependency name to csf_ke

### DIFF
--- a/kenya_compliance_via_slade/hooks.py
+++ b/kenya_compliance_via_slade/hooks.py
@@ -4,7 +4,7 @@ app_publisher = "Navari Ltd"
 app_description = "This app works to integrate ERPNext with KRA's eTIMS via Slade360 Advantage to allow for the sharing of information with the revenue authority."
 app_email = "support@navari.co.ke"
 app_license = "GNU Affero General Public License v3.0"
-required_apps = ["erpnext", "navariltd/navari_csf_ke"]
+required_apps = ["erpnext", "csf_ke"]
 
 
 # Fixtures


### PR DESCRIPTION
Update the 'Required Apps List' in 'hooks.py' to point to the correct 'Package Name' 'csf_ke' instead of the deprecated 'navariltd/navari_csf_ke', ensuring the application resolves its 'dependencies' correctly within the 'Environment'.

- Replace deprecated navariltd/navari_csf_ke with csf_ke.
- Ensure correct dependency resolution in hooks configuration.
- Maintain compatibility with updated package naming.