### PR TITLE
chore: fix app dependency path for navariltd/csf_ke

### DIFF
--- a/kenya_compliance_via_slade/hooks.py
+++ b/kenya_compliance_via_slade/hooks.py
@@ -4,7 +4,7 @@ app_publisher = "Navari Ltd"
 app_description = "This app works to integrate ERPNext with KRA's eTIMS via Slade360 Advantage to allow for the sharing of information with the revenue authority."
 app_email = "support@navari.co.ke"
 app_license = "GNU Affero General Public License v3.0"
-required_apps = ["erpnext", "csf_ke"]
+required_apps = ["erpnext", "navariltd/csf_ke"]
 
 
 # Fixtures


### PR DESCRIPTION
This pull request makes a minor update to the `kenya_compliance_via_slade/hooks.py` file, specifically changing the way a required app is referenced to include its full path.

- Changed the `required_apps` entry for `csf_ke` to use the full path `navariltd/csf_ke` for clarity and to ensure the correct app is referenced.