### PR TITLE
Fix eTIMS submission logic and enable hanging field cleanup

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
@@ -20,7 +20,7 @@ frappe.ui.form.on(parentDoctype, {
       clearEtimsHtmlAndWarnings(frm);
       return;
     }
-    if (frm.doc.is_opening) {
+    if (frm.doc.is_opening == "Yes") {
       clearEtimsHtmlAndWarnings(frm);
       frm.set_value("prevent_etims_submission", 1);
       return;

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -2448,11 +2448,11 @@ def delete_hanging_custom_fields():
         "Item",
         "Item Group",
         "Customer",
-        # "Sales Invoice",
-        # "Sales Invoice Item",
+        "Sales Invoice",
+        "Sales Invoice Item",
         "Item Tax Template",
         "Supplier",
-        # "Stock Ledger Entry",
+        "Stock Ledger Entry",
         "Sales Taxes and Charges Template",
     ]
 


### PR DESCRIPTION
This pull request makes two targeted updates to improve compliance logic and data cleanup in the Kenya Compliance app. The first change ensures that the check for opening invoices is more robust by comparing against the string "Yes". The second change updates the list of doctypes for which custom fields can be deleted, now including previously commented-out doctypes.

Logic correction in client-side validation:

* Updated the check for opening invoices in `sales_invoice.js` to use a strict string comparison (`frm.doc.is_opening == "Yes"`) instead of a truthy check, ensuring proper handling of the "is_opening" field.

Data cleanup enhancements:

* In `utils.py`, re-enabled deletion of custom fields for `Sales Invoice`, `Sales Invoice Item`, and `Stock Ledger Entry` doctypes by uncommenting them in the list, allowing for more comprehensive cleanup of hanging custom fields.