### PR TITLE
fix: correct opening invoice condition check for eTIMS submission

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
@@ -20,7 +20,7 @@ frappe.ui.form.on(parentDoctype, {
       clearEtimsHtmlAndWarnings(frm);
       return;
     }
-    if (frm.doc.is_opening) {
+    if (frm.doc.is_opening == "Yes") {
       clearEtimsHtmlAndWarnings(frm);
       frm.set_value("prevent_etims_submission", 1);
       return;


### PR DESCRIPTION
Update the 'Validation Logic' for 'Opening Invoices' to correctly  check for the 'String Value' 'Yes', ensuring the eTIMS  'Submission Prevention Logic' triggers accurately when an opening  invoice is detected and preventing 'Validation Errors' caused by  strict 'Boolean Comparisons'.

- Fix condition to check for 'Yes' string on is_opening field.
- Ensure submission blocking works correctly for opening invoices.
- Prevent validation errors from boolean comparison mismatches.