### PR TITLE
fix: use ERPNext tax row fields for hierarchy tax calculation

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -689,7 +689,9 @@ def _calculate_taxes_by_hierarchy(doc: "Document") -> dict:
         elif template_rate > 0:
             rate = template_rate
         elif not has_item_templates and doc.get("taxes") and total_net > 0:
-            total_doc_tax = sum(float(t.etims_tax_amount or 0) for t in doc.taxes)
+            total_doc_tax = sum(
+                float(t.base_tax_amount or t.tax_amount or 0) for t in doc.taxes
+            )
             item_tax = total_doc_tax * (base_net / total_net)
             rate = (item_tax / base_net) * 100 if base_net else 0.0
 


### PR DESCRIPTION
This pull request updates the tax calculation logic in the `_calculate_taxes_by_hierarchy` function to improve how tax amounts are summed for documents. The change ensures that the tax calculation uses `base_tax_amount` if available, falling back to `tax_amount` when necessary, instead of relying solely on `etims_tax_amount`.

**Tax calculation improvements:**

* Updated the summing logic in `_calculate_taxes_by_hierarchy` (in `kenya_compliance_via_slade/utils.py`) to use `base_tax_amount` or `tax_amount` for each tax entry, instead of only `etims_tax_amount`, making the tax computation more robust and accurate.