### PR TITLE
refactor: remove redundant invoice_type argument from fetch task

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
@@ -531,7 +531,6 @@ def handle_invoice_sign_success(
     frappe.enqueue(
         "kenya_compliance_via_slade.kenya_compliance_via_slade.background_tasks.tasks.fetch_etims_sales_invoices",
         document_name=document_name,
-        invoice_type=doctype,
         request_data=request_data,
         queue="long",
     )


### PR DESCRIPTION
Remove the 'invoice_type' argument from the background task  'fetch_etims_sales_invoices' triggered after a successful  invoice 'Signature', as the argument was identified as  'Redundant' and the underlying task handles required 'Data  Retrieval' independently to simplify the 'Task Signature' and  reduce unnecessary 'Data Passing'.

- Remove invoice_type parameter from fetch task call.
- Simplify background task signature.
- Reduce unnecessary argument passing.