### PR TITLE
feat: enhance eTIMS settings, UI, and metrics with various improvements

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/apis.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/apis.py
@@ -563,11 +563,7 @@ def send_branch_customer_details(
 
     partner_name = data.customer_name if is_customer else data.supplier_name
 
-    request_data = (
-        {"customer_tax_pin": data.tax_id, "document_name": name}
-        if hasattr(data, "tax_id") and data.tax_id not in (None, "")
-        else {"partner_name": partner_name, "document_name": name}
-    )
+    request_data = {"partner_name": partner_name, "document_name": name}
 
     process_request(
         request_data,

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/apis.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/apis.py
@@ -1440,10 +1440,28 @@ def submit_credit_note(
 ) -> None:
     """Submit credit note"""
     doc = frappe.get_doc(doctype, document_name)
-    data = response.get("results", [])[0] if response.get("results") else response
+    slade_id = frappe.db.get_value("Sales Invoice", doc.return_against, "etims_id")
+
+    results = response.get("results", [])
+    data = None
+
+    if results:
+        for result in results:
+            if result.get("id") == slade_id:
+                data = result
+                break
+        if not data:
+            data = results[0]
+    else:
+        data = response
+
+    if not data:
+        return
+
     scu_data = data.get("scu_data")
     if not scu_data:
         return
+
     payload = build_return_invoice_payload(doc, data)
     frappe.enqueue(
         process_request,

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/apis/remote_response_status_handlers.py
@@ -307,13 +307,25 @@ def sales_information_submission_on_success(
     """
     Callback after successful submission. Maps SCU data and signature_link.
     """
+
+    settings_doc = frappe.get_doc(SETTINGS_DOCTYPE_NAME, settings_name)
+    doc = frappe.get_doc(doctype, document_name)
+
     updates = {
         "sent_to_etims": 1,
         "etims_id": response.get("sales_invoice_id"),
         "etims_qr_code_url": response.get("signature_link"),
     }
 
+    if not settings_doc.enable_verification_redirect and response.get("signature_link"):
+        updates["etims_qr_image"] = generate_and_attach_qr_code(
+            response.get("signature_link"),
+            doc.name,
+            doc.doctype,
+        )
+
     frappe.db.set_value(doctype, document_name, updates)
+
     doc = frappe.get_doc(doctype, document_name)
     invoice_name = doc.return_against if doc.is_return else document_name
 

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/tasks.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/background_tasks/tasks.py
@@ -730,20 +730,20 @@ def fetch_etims_sales_invoices(
 ) -> None:
     request_data = parse_request_data(request_data) or {}
 
-    if "invoice_date_before" not in request_data:
-        request_data["invoice_date_before"] = now_datetime().date().isoformat()
-    if "invoice_date_after" not in request_data:
-        invoice_date_before_obj = now_datetime().date()
-        request_data["invoice_date_after"] = (
-            invoice_date_before_obj - timedelta(days=1)
-        ).isoformat()
-
     doc = frappe.get_doc("Sales Invoice", document_name) if document_name else None
     if doc and doc.is_return:
         document_name = doc.return_against
     if document_name:
         request_data["search"] = document_name
 
+    else:
+        if "invoice_date_before" not in request_data:
+            request_data["invoice_date_before"] = now_datetime().date().isoformat()
+        if "invoice_date_after" not in request_data:
+            invoice_date_before_obj = now_datetime().date()
+            request_data["invoice_date_after"] = (
+                invoice_date_before_obj - timedelta(days=1)
+            ).isoformat()
     process_request(
         request_data,
         "TrnsSalesSaveWrReq",

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/navari_kra_etims_settings/navari_kra_etims_settings.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/doctype/navari_kra_etims_settings/navari_kra_etims_settings.json
@@ -1,665 +1,673 @@
 {
-  "actions": [],
-  "allow_rename": 1,
-  "autoname": "hash",
-  "creation": "2024-02-19 01:07:18.311952",
-  "doctype": "DocType",
-  "engine": "InnoDB",
-  "field_order": [
-    "environment_section",
-    "env",
-    "sandbox",
-    "column_break_swix",
-    "is_active",
-    "settings_section",
-    "server_url",
-    "auth_server_url",
-    "warehouse",
-    "workstation",
-    "column_break_mmvk",
-    "company",
-    "tin",
-    "bhfid",
-    "department",
-    "section_break_xyci",
-    "organisation_mapping",
-    "request_frequency_tab",
-    "frequency_of_communication_with_etims_servers_section",
-    "column_break_fsjl",
-    "notices_refresh_frequency",
-    "notices_refresh_freq_cron_format",
-    "column_break_fudf",
-    "codes_refresh_frequency",
-    "codes_refresh_freq_cron_format",
-    "section_break_kkbe",
-    "sales_auto_submission_enabled",
-    "sales_information_submission",
-    "max_allowed_revisions",
-    "column_break_ifui",
-    "purchase_auto_submission_enabled",
-    "purchase_information_submission",
-    "column_break_ukgx",
-    "stock_auto_submission_enabled",
-    "stock_information_submission",
-    "submission_timeframe_section",
-    "sales_information_submission_timeframe",
-    "maximum_sales_information_submission_attempts",
-    "column_break_xtvd",
-    "purchase_information_submission_timeframe",
-    "maximum_purchase_information_submission_attempts",
-    "column_break_wyiz",
-    "stock_information_submission_timeframe",
-    "maximum_stock_information_submission_attempts",
-    "field_defaults_tab",
-    "item_defaults_section",
-    "etims_country_of_origin",
-    "etims_taxation_type",
-    "etims_item_classification",
-    "column_break_pybw",
-    "etims_country_of_origin_code",
-    "etims_taxation_type_name",
-    "item_classification_name",
-    "packaging_unit_details_section",
-    "etims_packaging_unit",
-    "column_break_jaqq",
-    "etims_packaging_unit_code",
-    "unit_of_quantity_details_section",
-    "etims_unit_of_quantity",
-    "column_break_oqib",
-    "etims_unit_of_quantity_code",
-    "product_type_details_section",
-    "etims_product_type",
-    "etims_item_type",
-    "column_break_dxoa",
-    "etims_product_type_name",
-    "etims_item_type_name",
-    "auth_details_tab",
-    "client_id",
-    "client_secret",
-    "column_break_ekvx",
-    "auth_username",
-    "auth_password",
-    "reset_auth_password",
-    "section_break_eqay",
-    "access_token",
-    "column_break_clyl",
-    "refresh_token",
-    "get_new_token",
-    "column_break_uosd",
-    "token_expiry",
-    "expires_in"
-  ],
-  "fields": [
-    {
-      "fieldname": "settings_section",
-      "fieldtype": "Section Break",
-      "label": "Settings Definition"
-    },
-    {
-      "default": "1",
-      "description": "Marks current environment as either Sandbox, or Production.",
-      "fieldname": "sandbox",
-      "fieldtype": "Check",
-      "label": "Sandbox Environment",
-      "no_copy": 1
-    },
-    {
-      "default": "https://api-dev.slade360edi.com/erp",
-      "description": "Slade360 Server URL. Don't fill if you're not sure what to input.",
-      "fieldname": "server_url",
-      "fieldtype": "Data",
-      "label": "Server URL",
-      "options": "URL",
-      "reqd": 1
-    },
-    {
-      "fetch_from": "company.tax_id",
-      "fieldname": "tin",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "Tax Payer's PIN"
-    },
-    {
-      "description": "00 is Head-Office/Headquarters, 01 to 99 is Branch Office",
-      "fieldname": "bhfid",
-      "fieldtype": "Link",
-      "hidden": 1,
-      "in_list_view": 1,
-      "in_standard_filter": 1,
-      "label": "Branch Id",
-      "no_copy": 1,
-      "options": "Branch"
-    },
-    {
-      "fieldname": "environment_section",
-      "fieldtype": "Section Break",
-      "label": "Environment"
-    },
-    {
-      "fieldname": "column_break_mmvk",
-      "fieldtype": "Column Break"
-    },
-    {
-      "default": "Sandbox",
-      "fieldname": "env",
-      "fieldtype": "Select",
-      "in_list_view": 1,
-      "label": "Environment",
-      "options": "\nSandbox\nProduction",
-      "read_only": 1
-    },
-    {
-      "fieldname": "column_break_swix",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "company",
-      "fieldtype": "Link",
-      "in_list_view": 1,
-      "label": "Company",
-      "options": "Company",
-      "reqd": 1
-    },
-    {
-      "default": "0",
-      "fieldname": "is_active",
-      "fieldtype": "Check",
-      "in_list_view": 1,
-      "label": "Is Active",
-      "options": "1"
-    },
-    {
-      "fieldname": "request_frequency_tab",
-      "fieldtype": "Tab Break",
-      "label": "Submission Frequency Settings"
-    },
-    {
-      "fieldname": "frequency_of_communication_with_etims_servers_section",
-      "fieldtype": "Section Break",
-      "label": "Frequency of Communication with eTims Servers"
-    },
-    {
-      "default": "Both",
-      "depends_on": "eval: doc.sales_auto_submission_enabled == 1",
-      "fieldname": "sales_information_submission",
-      "fieldtype": "Select",
-      "label": "Sales Information Submission Frequency",
-      "options": "Hourly\nDaily\nBoth"
-    },
-    {
-      "fieldname": "column_break_ukgx",
-      "fieldtype": "Column Break"
-    },
-    {
-      "default": "Both",
-      "depends_on": "eval: doc.stock_auto_submission_enabled == 1",
-      "fieldname": "stock_information_submission",
-      "fieldtype": "Select",
-      "label": "Stock Information Submission Frequency",
-      "options": "Hourly\nDaily\nBoth"
-    },
-    {
-      "fieldname": "column_break_ifui",
-      "fieldtype": "Column Break"
-    },
-    {
-      "default": "Both",
-      "depends_on": "eval: doc.purchase_auto_submission_enabled == 1",
-      "fieldname": "purchase_information_submission",
-      "fieldtype": "Select",
-      "label": "Purchase Information Submission Frequency",
-      "mandatory_depends_on": "eval:doc.purchase_information_submission === \"Cron Format\";",
-      "options": "Hourly\nDaily\nBoth"
-    },
-    {
-      "fieldname": "field_defaults_tab",
-      "fieldtype": "Tab Break",
-      "label": "Field Defaults"
-    },
-    {
-      "fieldname": "column_break_fsjl",
-      "fieldtype": "Column Break"
-    },
-    {
-      "default": "Hourly",
-      "fieldname": "notices_refresh_frequency",
-      "fieldtype": "Select",
-      "label": "Notices Refresh Frequency",
-      "options": "\nAll\nHourly\nDaily\nWeekly\nMonthly\nYearly\nAnnual\nCron"
-    },
-    {
-      "depends_on": "eval:doc.notices_refresh_frequency === \"Cron\";",
-      "fieldname": "notices_refresh_freq_cron_format",
-      "fieldtype": "Data",
-      "label": "Notices Refresh Freq. Cron Format",
-      "mandatory_depends_on": "eval:doc.notices_refresh_frequency === \"Cron\";"
-    },
-    {
-      "fieldname": "auth_details_tab",
-      "fieldtype": "Tab Break",
-      "label": "Auth Details"
-    },
-    {
-      "fieldname": "client_id",
-      "fieldtype": "Data",
-      "label": "Client ID",
-      "reqd": 1
-    },
-    {
-      "fieldname": "client_secret",
-      "fieldtype": "Password",
-      "label": "Client Secret",
-      "reqd": 1
-    },
-    {
-      "fieldname": "column_break_ekvx",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "auth_username",
-      "fieldtype": "Data",
-      "label": "Auth Username",
-      "reqd": 1
-    },
-    {
-      "fieldname": "auth_password",
-      "fieldtype": "Password",
-      "label": "Auth Password",
-      "reqd": 1
-    },
-    {
-      "fieldname": "access_token",
-      "fieldtype": "Data",
-      "label": "Access Token",
-      "no_copy": 1,
-      "read_only": 1
-    },
-    {
-      "fieldname": "refresh_token",
-      "fieldtype": "Data",
-      "label": "Refresh Token",
-      "no_copy": 1,
-      "read_only": 1
-    },
-    {
-      "fieldname": "expires_in",
-      "fieldtype": "Data",
-      "label": "Expires In",
-      "no_copy": 1,
-      "read_only": 1
-    },
-    {
-      "fieldname": "token_expiry",
-      "fieldtype": "Datetime",
-      "label": "Token Expiry",
-      "no_copy": 1
-    },
-    {
-      "fieldname": "section_break_eqay",
-      "fieldtype": "Section Break"
-    },
-    {
-      "fieldname": "column_break_clyl",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "column_break_uosd",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fetch_from": "etims_user.workstation",
-      "fieldname": "workstation",
-      "fieldtype": "Link",
-      "hidden": 1,
-      "label": "Workstation",
-      "options": "Navari KRA eTims Workstation"
-    },
-    {
-      "default": "https://accounts.multitenant.slade360.co.ke",
-      "description": "Slade360 Auth Server URL. Don't fill if you're not sure what to input.",
-      "fieldname": "auth_server_url",
-      "fieldtype": "Data",
-      "label": "Auth Server URL",
-      "options": "URL",
-      "reqd": 1
-    },
-    {
-      "fieldname": "department",
-      "fieldtype": "Link",
-      "hidden": 1,
-      "in_list_view": 1,
-      "in_standard_filter": 1,
-      "label": "Department",
-      "no_copy": 1,
-      "options": "Department"
-    },
-    {
-      "depends_on": "eval: doc.sales_auto_submission_enabled == 1",
-      "fieldname": "sales_information_submission_timeframe",
-      "fieldtype": "Duration",
-      "label": "Sales Information Submission Timeframe"
-    },
-    {
-      "depends_on": "eval: doc.stock_auto_submission_enabled == 1",
-      "fieldname": "stock_information_submission_timeframe",
-      "fieldtype": "Duration",
-      "label": "Stock Information Submission Timeframe"
-    },
-    {
-      "depends_on": "eval: doc.purchase_auto_submission_enabled == 1",
-      "fieldname": "purchase_information_submission_timeframe",
-      "fieldtype": "Duration",
-      "label": "Purchase Information Submission Timeframe"
-    },
-    {
-      "description": "Defines the allowed period for entries to be sent to eTIMS, such as invoices and purchases, from the current time. For example, if set to 4 days, entries can only be sent within the last 4 days.",
-      "fieldname": "submission_timeframe_section",
-      "fieldtype": "Section Break",
-      "label": "Submission Timeframe"
-    },
-    {
-      "fieldname": "column_break_xtvd",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "column_break_wyiz",
-      "fieldtype": "Column Break"
-    },
-    {
-      "depends_on": "eval: doc.sales_auto_submission_enabled == 1",
-      "description": "Maximum attempts allowed to resubmit failed sales invoices before restrictions apply.",
-      "fieldname": "maximum_sales_information_submission_attempts",
-      "fieldtype": "Int",
-      "label": "Max Sales Submission Attempts"
-    },
-    {
-      "depends_on": "eval: doc.purchase_auto_submission_enabled == 1",
-      "description": "Maximum attempts allowed to resubmit failed purchase invoices before restrictions apply.",
-      "fieldname": "maximum_purchase_information_submission_attempts",
-      "fieldtype": "Int",
-      "label": "Max Purchase Submission Attempts"
-    },
-    {
-      "depends_on": "eval: doc.stock_auto_submission_enabled == 1",
-      "description": "Maximum attempts allowed to resubmit failed stock operations before restrictions apply.",
-      "fieldname": "maximum_stock_information_submission_attempts",
-      "fieldtype": "Int",
-      "label": "Max Stock Submission Attempts"
-    },
-    {
-      "default": "0",
-      "fieldname": "sales_auto_submission_enabled",
-      "fieldtype": "Check",
-      "label": "Sales Auto Submission Enabled"
-    },
-    {
-      "default": "0",
-      "fieldname": "purchase_auto_submission_enabled",
-      "fieldtype": "Check",
-      "label": "Purchase Auto Submission Enabled"
-    },
-    {
-      "default": "0",
-      "fieldname": "stock_auto_submission_enabled",
-      "fieldtype": "Check",
-      "label": "Stock Auto Submission Enabled"
-    },
-    {
-      "fieldname": "section_break_kkbe",
-      "fieldtype": "Section Break"
-    },
-    {
-      "fieldname": "column_break_fudf",
-      "fieldtype": "Column Break"
-    },
-    {
-      "default": "Hourly",
-      "fieldname": "codes_refresh_frequency",
-      "fieldtype": "Select",
-      "label": "Codes Refresh Frequency",
-      "options": "\nAll\nHourly\nDaily\nWeekly\nMonthly\nYearly\nAnnual\nCron"
-    },
-    {
-      "depends_on": "eval:doc.codes_refresh_frequency === \"Cron\";",
-      "fieldname": "codes_refresh_freq_cron_format",
-      "fieldtype": "Data",
-      "label": "Codes Refresh Freq. Cron Format",
-      "mandatory_depends_on": "eval:doc.notices_refresh_frequency === \"Cron\";"
-    },
-    {
-      "fetch_from": "etims_user.workstation",
-      "fieldname": "warehouse",
-      "fieldtype": "Link",
-      "hidden": 1,
-      "label": "Default Warehouse",
-      "options": "Warehouse"
-    },
-    {
-      "fieldname": "get_new_token",
-      "fieldtype": "Button",
-      "label": "Get New Token"
-    },
-    {
-      "fieldname": "reset_auth_password",
-      "fieldtype": "Button",
-      "label": "Reset Auth Password"
-    },
-    {
-      "fieldname": "section_break_xyci",
-      "fieldtype": "Section Break"
-    },
-    {
-      "fieldname": "organisation_mapping",
-      "fieldtype": "Table",
-      "label": "Organisation Mapping",
-      "options": "eTims Settings Organisation Mapping"
-    },
-    {
-      "default": "1",
-      "fieldname": "max_allowed_revisions",
-      "fieldtype": "Int",
-      "label": "Max Allowed Revisions"
-    },
-    {
-      "fieldname": "item_defaults_section",
-      "fieldtype": "Section Break",
-      "label": "Item Classification Details"
-    },
-    {
-      "fieldname": "column_break_pybw",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fetch_from": "etims_item_classification.itemclsnm",
-      "fieldname": "item_classification_name",
-      "fieldtype": "Small Text",
-      "label": "Item Classification Name",
-      "read_only": 1
-    },
-    {
-      "fieldname": "etims_country_of_origin",
-      "fieldtype": "Link",
-      "label": "eTims Country of Origin",
-      "options": "eTims Country of Origin"
-    },
-    {
-      "fetch_from": "etims_country_of_origin.code",
-      "fieldname": "etims_country_of_origin_code",
-      "fieldtype": "Data",
-      "label": "eTims Country of Origin Code",
-      "read_only": 1
-    },
-    {
-      "fieldname": "etims_taxation_type",
-      "fieldtype": "Link",
-      "label": "Taxation Type",
-      "options": "eTims Taxation Type"
-    },
-    {
-      "fieldname": "packaging_unit_details_section",
-      "fieldtype": "Section Break",
-      "label": "Packaging Unit Details"
-    },
-    {
-      "fieldname": "etims_packaging_unit",
-      "fieldtype": "Link",
-      "label": "Packaging Unit",
-      "options": "eTims Packaging Unit"
-    },
-    {
-      "fieldname": "column_break_jaqq",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fetch_from": "etims_packaging_unit.code_name",
-      "fieldname": "etims_packaging_unit_code",
-      "fieldtype": "Data",
-      "label": "Packaging Unit Code",
-      "read_only": 1
-    },
-    {
-      "fieldname": "unit_of_quantity_details_section",
-      "fieldtype": "Section Break",
-      "label": "Unit of Quantity Details"
-    },
-    {
-      "fieldname": "etims_unit_of_quantity",
-      "fieldtype": "Link",
-      "label": "Unit of Quantity",
-      "options": "eTims Unit of Quantity"
-    },
-    {
-      "fieldname": "column_break_oqib",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fetch_from": "etims_unit_of_quantity.code_name",
-      "fieldname": "etims_unit_of_quantity_code",
-      "fieldtype": "Data",
-      "label": "Unit of Quantity Code",
-      "read_only": 1
-    },
-    {
-      "fieldname": "product_type_details_section",
-      "fieldtype": "Section Break",
-      "label": "Product Type Details"
-    },
-    {
-      "fieldname": "column_break_dxoa",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fetch_from": "etims_product_type.code_name",
-      "fieldname": "etims_product_type_name",
-      "fieldtype": "Data",
-      "label": "Product Type Name",
-      "read_only": 1
-    },
-    {
-      "fetch_from": "etims_item_type.code_name",
-      "fieldname": "etims_item_type_name",
-      "fieldtype": "Data",
-      "label": "Item Type Name",
-      "read_only": 1
-    },
-    {
-      "fieldname": "etims_item_type",
-      "fieldtype": "Link",
-      "label": "eTims Item Type",
-      "options": "eTims Item Type"
-    },
-    {
-      "fieldname": "etims_item_classification",
-      "fieldtype": "Link",
-      "label": "Item Classification Code",
-      "options": "eTims Item Classification"
-    },
-    {
-      "fetch_from": "etims_taxation_type.cdnm",
-      "fieldname": "etims_taxation_type_name",
-      "fieldtype": "Data",
-      "label": "Taxation Type Name",
-      "read_only": 1
-    },
-    {
-      "fieldname": "etims_product_type",
-      "fieldtype": "Link",
-      "label": "Product Type Code",
-      "options": "eTims Product Type"
-    }
-  ],
-  "grid_page_length": 50,
-  "index_web_pages_for_search": 1,
-  "links": [
-    {
-      "group": "Linked Requests",
-      "link_doctype": "Integration Request",
-      "link_fieldname": "reference_docname"
-    }
-  ],
-  "modified": "2026-06-05 17:28:29.846188",
-  "modified_by": "Administrator",
-  "module": "Kenya Compliance Via Slade",
-  "name": "Navari KRA eTims Settings",
-  "naming_rule": "Random",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-    },
-    {
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Accounts Manager",
-      "share": 1,
-      "write": 1
-    },
-    {
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Accounts User",
-      "share": 1,
-      "write": 1
-    },
-    {
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Sales Manager",
-      "share": 1,
-      "write": 1
-    },
-    {
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Sales User",
-      "share": 1,
-      "write": 1
-    }
-  ],
-  "row_format": "Dynamic",
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "states": [],
-  "track_changes": 1
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "hash",
+ "creation": "2024-02-19 01:07:18.311952",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "environment_section",
+  "env",
+  "sandbox",
+  "column_break_swix",
+  "is_active",
+  "settings_section",
+  "server_url",
+  "auth_server_url",
+  "warehouse",
+  "workstation",
+  "column_break_mmvk",
+  "company",
+  "tin",
+  "bhfid",
+  "department",
+  "section_break_xyci",
+  "organisation_mapping",
+  "request_frequency_tab",
+  "frequency_of_communication_with_etims_servers_section",
+  "column_break_fsjl",
+  "notices_refresh_frequency",
+  "notices_refresh_freq_cron_format",
+  "column_break_fudf",
+  "codes_refresh_frequency",
+  "codes_refresh_freq_cron_format",
+  "section_break_kkbe",
+  "sales_auto_submission_enabled",
+  "sales_information_submission",
+  "max_allowed_revisions",
+  "enable_verification_redirect",
+  "column_break_ifui",
+  "purchase_auto_submission_enabled",
+  "purchase_information_submission",
+  "column_break_ukgx",
+  "stock_auto_submission_enabled",
+  "stock_information_submission",
+  "submission_timeframe_section",
+  "sales_information_submission_timeframe",
+  "maximum_sales_information_submission_attempts",
+  "column_break_xtvd",
+  "purchase_information_submission_timeframe",
+  "maximum_purchase_information_submission_attempts",
+  "column_break_wyiz",
+  "stock_information_submission_timeframe",
+  "maximum_stock_information_submission_attempts",
+  "field_defaults_tab",
+  "item_defaults_section",
+  "etims_country_of_origin",
+  "etims_taxation_type",
+  "etims_item_classification",
+  "column_break_pybw",
+  "etims_country_of_origin_code",
+  "etims_taxation_type_name",
+  "item_classification_name",
+  "packaging_unit_details_section",
+  "etims_packaging_unit",
+  "column_break_jaqq",
+  "etims_packaging_unit_code",
+  "unit_of_quantity_details_section",
+  "etims_unit_of_quantity",
+  "column_break_oqib",
+  "etims_unit_of_quantity_code",
+  "product_type_details_section",
+  "etims_product_type",
+  "etims_item_type",
+  "column_break_dxoa",
+  "etims_product_type_name",
+  "etims_item_type_name",
+  "auth_details_tab",
+  "client_id",
+  "client_secret",
+  "column_break_ekvx",
+  "auth_username",
+  "auth_password",
+  "reset_auth_password",
+  "section_break_eqay",
+  "access_token",
+  "column_break_clyl",
+  "refresh_token",
+  "get_new_token",
+  "column_break_uosd",
+  "token_expiry",
+  "expires_in"
+ ],
+ "fields": [
+  {
+   "fieldname": "settings_section",
+   "fieldtype": "Section Break",
+   "label": "Settings Definition"
+  },
+  {
+   "default": "1",
+   "description": "Marks current environment as either Sandbox, or Production.",
+   "fieldname": "sandbox",
+   "fieldtype": "Check",
+   "label": "Sandbox Environment",
+   "no_copy": 1
+  },
+  {
+   "default": "https://api-dev.slade360edi.com/erp",
+   "description": "Slade360 Server URL. Don't fill if you're not sure what to input.",
+   "fieldname": "server_url",
+   "fieldtype": "Data",
+   "label": "Server URL",
+   "options": "URL",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "company.tax_id",
+   "fieldname": "tin",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Tax Payer's PIN"
+  },
+  {
+   "description": "00 is Head-Office/Headquarters, 01 to 99 is Branch Office",
+   "fieldname": "bhfid",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Branch Id",
+   "no_copy": 1,
+   "options": "Branch"
+  },
+  {
+   "fieldname": "environment_section",
+   "fieldtype": "Section Break",
+   "label": "Environment"
+  },
+  {
+   "fieldname": "column_break_mmvk",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Sandbox",
+   "fieldname": "env",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Environment",
+   "options": "\nSandbox\nProduction",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_swix",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_active",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Is Active",
+   "options": "1"
+  },
+  {
+   "fieldname": "request_frequency_tab",
+   "fieldtype": "Tab Break",
+   "label": "Submission Frequency Settings"
+  },
+  {
+   "fieldname": "frequency_of_communication_with_etims_servers_section",
+   "fieldtype": "Section Break",
+   "label": "Frequency of Communication with eTims Servers"
+  },
+  {
+   "default": "Both",
+   "depends_on": "eval: doc.sales_auto_submission_enabled == 1",
+   "fieldname": "sales_information_submission",
+   "fieldtype": "Select",
+   "label": "Sales Information Submission Frequency",
+   "options": "Hourly\nDaily\nBoth"
+  },
+  {
+   "fieldname": "column_break_ukgx",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Both",
+   "depends_on": "eval: doc.stock_auto_submission_enabled == 1",
+   "fieldname": "stock_information_submission",
+   "fieldtype": "Select",
+   "label": "Stock Information Submission Frequency",
+   "options": "Hourly\nDaily\nBoth"
+  },
+  {
+   "fieldname": "column_break_ifui",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Both",
+   "depends_on": "eval: doc.purchase_auto_submission_enabled == 1",
+   "fieldname": "purchase_information_submission",
+   "fieldtype": "Select",
+   "label": "Purchase Information Submission Frequency",
+   "mandatory_depends_on": "eval:doc.purchase_information_submission === \"Cron Format\";",
+   "options": "Hourly\nDaily\nBoth"
+  },
+  {
+   "fieldname": "field_defaults_tab",
+   "fieldtype": "Tab Break",
+   "label": "Field Defaults"
+  },
+  {
+   "fieldname": "column_break_fsjl",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Hourly",
+   "fieldname": "notices_refresh_frequency",
+   "fieldtype": "Select",
+   "label": "Notices Refresh Frequency",
+   "options": "\nAll\nHourly\nDaily\nWeekly\nMonthly\nYearly\nAnnual\nCron"
+  },
+  {
+   "depends_on": "eval:doc.notices_refresh_frequency === \"Cron\";",
+   "fieldname": "notices_refresh_freq_cron_format",
+   "fieldtype": "Data",
+   "label": "Notices Refresh Freq. Cron Format",
+   "mandatory_depends_on": "eval:doc.notices_refresh_frequency === \"Cron\";"
+  },
+  {
+   "fieldname": "auth_details_tab",
+   "fieldtype": "Tab Break",
+   "label": "Auth Details"
+  },
+  {
+   "fieldname": "client_id",
+   "fieldtype": "Data",
+   "label": "Client ID",
+   "reqd": 1
+  },
+  {
+   "fieldname": "client_secret",
+   "fieldtype": "Password",
+   "label": "Client Secret",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_ekvx",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "auth_username",
+   "fieldtype": "Data",
+   "label": "Auth Username",
+   "reqd": 1
+  },
+  {
+   "fieldname": "auth_password",
+   "fieldtype": "Password",
+   "label": "Auth Password",
+   "reqd": 1
+  },
+  {
+   "fieldname": "access_token",
+   "fieldtype": "Data",
+   "label": "Access Token",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "refresh_token",
+   "fieldtype": "Data",
+   "label": "Refresh Token",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "expires_in",
+   "fieldtype": "Data",
+   "label": "Expires In",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "token_expiry",
+   "fieldtype": "Datetime",
+   "label": "Token Expiry",
+   "no_copy": 1
+  },
+  {
+   "fieldname": "section_break_eqay",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_clyl",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_uosd",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "etims_user.workstation",
+   "fieldname": "workstation",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Workstation",
+   "options": "Navari KRA eTims Workstation"
+  },
+  {
+   "default": "https://accounts.multitenant.slade360.co.ke",
+   "description": "Slade360 Auth Server URL. Don't fill if you're not sure what to input.",
+   "fieldname": "auth_server_url",
+   "fieldtype": "Data",
+   "label": "Auth Server URL",
+   "options": "URL",
+   "reqd": 1
+  },
+  {
+   "fieldname": "department",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Department",
+   "no_copy": 1,
+   "options": "Department"
+  },
+  {
+   "depends_on": "eval: doc.sales_auto_submission_enabled == 1",
+   "fieldname": "sales_information_submission_timeframe",
+   "fieldtype": "Duration",
+   "label": "Sales Information Submission Timeframe"
+  },
+  {
+   "depends_on": "eval: doc.stock_auto_submission_enabled == 1",
+   "fieldname": "stock_information_submission_timeframe",
+   "fieldtype": "Duration",
+   "label": "Stock Information Submission Timeframe"
+  },
+  {
+   "depends_on": "eval: doc.purchase_auto_submission_enabled == 1",
+   "fieldname": "purchase_information_submission_timeframe",
+   "fieldtype": "Duration",
+   "label": "Purchase Information Submission Timeframe"
+  },
+  {
+   "description": "Defines the allowed period for entries to be sent to eTIMS, such as invoices and purchases, from the current time. For example, if set to 4 days, entries can only be sent within the last 4 days.",
+   "fieldname": "submission_timeframe_section",
+   "fieldtype": "Section Break",
+   "label": "Submission Timeframe"
+  },
+  {
+   "fieldname": "column_break_xtvd",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_wyiz",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval: doc.sales_auto_submission_enabled == 1",
+   "description": "Maximum attempts allowed to resubmit failed sales invoices before restrictions apply.",
+   "fieldname": "maximum_sales_information_submission_attempts",
+   "fieldtype": "Int",
+   "label": "Max Sales Submission Attempts"
+  },
+  {
+   "depends_on": "eval: doc.purchase_auto_submission_enabled == 1",
+   "description": "Maximum attempts allowed to resubmit failed purchase invoices before restrictions apply.",
+   "fieldname": "maximum_purchase_information_submission_attempts",
+   "fieldtype": "Int",
+   "label": "Max Purchase Submission Attempts"
+  },
+  {
+   "depends_on": "eval: doc.stock_auto_submission_enabled == 1",
+   "description": "Maximum attempts allowed to resubmit failed stock operations before restrictions apply.",
+   "fieldname": "maximum_stock_information_submission_attempts",
+   "fieldtype": "Int",
+   "label": "Max Stock Submission Attempts"
+  },
+  {
+   "default": "0",
+   "fieldname": "sales_auto_submission_enabled",
+   "fieldtype": "Check",
+   "label": "Sales Auto Submission Enabled"
+  },
+  {
+   "default": "0",
+   "fieldname": "purchase_auto_submission_enabled",
+   "fieldtype": "Check",
+   "label": "Purchase Auto Submission Enabled"
+  },
+  {
+   "default": "0",
+   "fieldname": "stock_auto_submission_enabled",
+   "fieldtype": "Check",
+   "label": "Stock Auto Submission Enabled"
+  },
+  {
+   "fieldname": "section_break_kkbe",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_fudf",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Hourly",
+   "fieldname": "codes_refresh_frequency",
+   "fieldtype": "Select",
+   "label": "Codes Refresh Frequency",
+   "options": "\nAll\nHourly\nDaily\nWeekly\nMonthly\nYearly\nAnnual\nCron"
+  },
+  {
+   "depends_on": "eval:doc.codes_refresh_frequency === \"Cron\";",
+   "fieldname": "codes_refresh_freq_cron_format",
+   "fieldtype": "Data",
+   "label": "Codes Refresh Freq. Cron Format",
+   "mandatory_depends_on": "eval:doc.notices_refresh_frequency === \"Cron\";"
+  },
+  {
+   "fetch_from": "etims_user.workstation",
+   "fieldname": "warehouse",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Default Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "fieldname": "get_new_token",
+   "fieldtype": "Button",
+   "label": "Get New Token"
+  },
+  {
+   "fieldname": "reset_auth_password",
+   "fieldtype": "Button",
+   "label": "Reset Auth Password"
+  },
+  {
+   "fieldname": "section_break_xyci",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "organisation_mapping",
+   "fieldtype": "Table",
+   "label": "Organisation Mapping",
+   "options": "eTims Settings Organisation Mapping"
+  },
+  {
+   "default": "1",
+   "fieldname": "max_allowed_revisions",
+   "fieldtype": "Int",
+   "label": "Max Allowed Revisions"
+  },
+  {
+   "fieldname": "item_defaults_section",
+   "fieldtype": "Section Break",
+   "label": "Item Classification Details"
+  },
+  {
+   "fieldname": "column_break_pybw",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "etims_item_classification.itemclsnm",
+   "fieldname": "item_classification_name",
+   "fieldtype": "Small Text",
+   "label": "Item Classification Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "etims_country_of_origin",
+   "fieldtype": "Link",
+   "label": "eTims Country of Origin",
+   "options": "eTims Country of Origin"
+  },
+  {
+   "fetch_from": "etims_country_of_origin.code",
+   "fieldname": "etims_country_of_origin_code",
+   "fieldtype": "Data",
+   "label": "eTims Country of Origin Code",
+   "read_only": 1
+  },
+  {
+   "fieldname": "etims_taxation_type",
+   "fieldtype": "Link",
+   "label": "Taxation Type",
+   "options": "eTims Taxation Type"
+  },
+  {
+   "fieldname": "packaging_unit_details_section",
+   "fieldtype": "Section Break",
+   "label": "Packaging Unit Details"
+  },
+  {
+   "fieldname": "etims_packaging_unit",
+   "fieldtype": "Link",
+   "label": "Packaging Unit",
+   "options": "eTims Packaging Unit"
+  },
+  {
+   "fieldname": "column_break_jaqq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "etims_packaging_unit.code_name",
+   "fieldname": "etims_packaging_unit_code",
+   "fieldtype": "Data",
+   "label": "Packaging Unit Code",
+   "read_only": 1
+  },
+  {
+   "fieldname": "unit_of_quantity_details_section",
+   "fieldtype": "Section Break",
+   "label": "Unit of Quantity Details"
+  },
+  {
+   "fieldname": "etims_unit_of_quantity",
+   "fieldtype": "Link",
+   "label": "Unit of Quantity",
+   "options": "eTims Unit of Quantity"
+  },
+  {
+   "fieldname": "column_break_oqib",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "etims_unit_of_quantity.code_name",
+   "fieldname": "etims_unit_of_quantity_code",
+   "fieldtype": "Data",
+   "label": "Unit of Quantity Code",
+   "read_only": 1
+  },
+  {
+   "fieldname": "product_type_details_section",
+   "fieldtype": "Section Break",
+   "label": "Product Type Details"
+  },
+  {
+   "fieldname": "column_break_dxoa",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "etims_product_type.code_name",
+   "fieldname": "etims_product_type_name",
+   "fieldtype": "Data",
+   "label": "Product Type Name",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "etims_item_type.code_name",
+   "fieldname": "etims_item_type_name",
+   "fieldtype": "Data",
+   "label": "Item Type Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "etims_item_type",
+   "fieldtype": "Link",
+   "label": "eTims Item Type",
+   "options": "eTims Item Type"
+  },
+  {
+   "fieldname": "etims_item_classification",
+   "fieldtype": "Link",
+   "label": "Item Classification Code",
+   "options": "eTims Item Classification"
+  },
+  {
+   "fetch_from": "etims_taxation_type.cdnm",
+   "fieldname": "etims_taxation_type_name",
+   "fieldtype": "Data",
+   "label": "Taxation Type Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "etims_product_type",
+   "fieldtype": "Link",
+   "label": "Product Type Code",
+   "options": "eTims Product Type"
+  },
+  {
+   "default": "0",
+   "description": "When enabled, invoice QR codes point to the ERP verification page, which checks the invoice\u2019s eTIMS submission status and redirects to the official eTIMS verification URL when available. When disabled, QR codes point directly to the eTIMS verification URL.",
+   "fieldname": "enable_verification_redirect",
+   "fieldtype": "Check",
+   "label": "Enable Verification Redirect"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [
+  {
+   "group": "Linked Requests",
+   "link_doctype": "Integration Request",
+   "link_fieldname": "reference_docname"
+  }
+ ],
+ "modified": "2026-07-02 09:32:26.419367",
+ "modified_by": "Administrator",
+ "module": "Kenya Compliance Via Slade",
+ "name": "Navari KRA eTims Settings",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales User",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
 }

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/client/sales_invoice.js
@@ -38,15 +38,25 @@ frappe.ui.form.on(parentDoctype, {
 
     clearEtimsHtmlAndWarnings(frm);
 
+    let parsedSetting = activeSetting[0];
+    let settingsDoc = null;
+    if (parsedSetting && parsedSetting.name) {
+      settingsDoc = await frappe.db.get_doc(
+        settingsDoctypeName,
+        parsedSetting.name,
+      );
+    }
+
     const eligibilityData = await fetchEligibilityData(frm);
     const summaryData = await fetchAndRenderSummary(
       frm,
       activeSetting,
       eligibilityData,
+      settingsDoc,
     );
 
     if (frm.doc.docstatus !== 0) {
-      addCustomButtons(frm, activeSetting, summaryData);
+      addCustomButtons(frm, activeSetting, summaryData, settingsDoc);
     }
 
     if (
@@ -94,7 +104,12 @@ async function fetchEligibilityData(frm) {
   }
 }
 
-async function fetchAndRenderSummary(frm, activeSetting, eligibilityData) {
+async function fetchAndRenderSummary(
+  frm,
+  activeSetting,
+  eligibilityData,
+  settingsDoc,
+) {
   const htmlField = frm.fields_dict.etims_summary;
   if (!htmlField) return null;
 
@@ -154,13 +169,24 @@ async function fetchAndRenderSummary(frm, activeSetting, eligibilityData) {
       return null;
     }
 
-    const tableHtml = buildTransactionTableHtml(data.details, fmt);
+    const sortedDetails = [...(data.details || [])].sort((a, b) => {
+      const matchA = a.reference_number === frm.doc.name ? 1 : 0;
+      const matchB = b.reference_number === frm.doc.name ? 1 : 0;
+      return matchB - matchA;
+    });
+
+    const tableHtml = buildTransactionTableHtml(
+      sortedDetails,
+      fmt,
+      frm.doc.name,
+      settingsDoc,
+    );
 
     if (frm.doc.is_return) {
       htmlField.$wrapper.html(`
         ${SHARED_ETIMS_STYLES}
         <div class="etims-root">
-          <div class="etims-hero">
+          <div class="etims-hero theme-credit">
             <div>
               <div class="etims-hero-title">Return / Credit Note - Original eTIMS Summary</div>
               <div class="etims-hero-sub">${data.from_date || "—"} — ${data.to_date || "—"}</div>
@@ -174,8 +200,8 @@ async function fetchAndRenderSummary(frm, activeSetting, eligibilityData) {
           </div>
 
           <div class="etims-stats-grid-2x2">
-            <div class="etims-stat-card">
-              <div class="etims-stat-header">Invoices</div>
+            <div class="etims-stat-card border-credit">
+              <div class="etims-stat-header header-credit">Invoices</div>
               <div class="etims-stat-body">
                 <div class="etims-compare-row"><span class="etims-compare-label">System Baseline</span><span class="etims-compare-value erp">${fmt(data.metrics?.erp?.erp_invoice_gross)}</span></div>
                 <div class="etims-compare-row"><span class="etims-compare-label">eTIMS</span><span class="etims-compare-value etims">${fmt(data.metrics?.etims?.etims_invoice_gross)}</span></div>
@@ -186,11 +212,11 @@ async function fetchAndRenderSummary(frm, activeSetting, eligibilityData) {
               </div>
             </div>
 
-            <div class="etims-stat-card">
-              <div class="etims-stat-header">Credit Notes</div>
+            <div class="etims-stat-card border-credit">
+              <div class="etims-stat-header header-credit">Credit Notes</div>
               <div class="etims-stat-body">
-                <div class="etims-compare-row"><span class="etims-compare-label">System Baseline</span><span class="etims-compare-value erp">${fmt(data.metrics?.erp?.erp_credit_gross)}</span></div>
-                <div class="etims-compare-row"><span class="etims-compare-label">eTIMS</span><span class="etims-compare-value etims">${fmt(data.metrics?.etims?.etims_credit_gross)}</span></div>
+                <div class="etims-compare-row"><span class="etims-compare-label">System Baseline</span><span class="etims-compare-value erp-credit">${fmt(data.metrics?.erp?.erp_credit_gross)}</span></div>
+                <div class="etims-compare-row"><span class="etims-compare-label">eTIMS</span><span class="etims-compare-value etims-credit">${fmt(data.metrics?.etims?.etims_credit_gross)}</span></div>
                 <div class="etims-diff-section">
                   <div class="etims-diff-row"><span class="etims-diff-label">Difference</span><span class="etims-diff-amount ${data.metrics?.variance?.gross_difference >= 0 ? "positive" : "negative"}">${fmt(data.metrics?.variance?.gross_difference)}</span></div>
                   <div class="etims-diff-row"><span class="etims-diff-label">Difference %</span><div><span class="etims-diff-percent" style="font-size:13px;font-weight:700;">0.00%</span></div></div>
@@ -198,8 +224,8 @@ async function fetchAndRenderSummary(frm, activeSetting, eligibilityData) {
               </div>
             </div>
 
-            <div class="etims-stat-card">
-              <div class="etims-stat-header">Tax</div>
+            <div class="etims-stat-card border-credit">
+              <div class="etims-stat-header header-credit">Tax</div>
               <div class="etims-stat-body">
                 <div class="etims-compare-row"><span class="etims-compare-label">System Tax</span><span class="etims-compare-value erp">${fmt(data.metrics?.erp?.erp_invoice_tax)}</span></div>
                 <div class="etims-compare-row"><span class="etims-compare-label">eTIMS Tax</span><span class="etims-compare-value etims">${fmt(data.metrics?.etims?.etims_invoice_tax)}</span></div>
@@ -210,8 +236,8 @@ async function fetchAndRenderSummary(frm, activeSetting, eligibilityData) {
               </div>
             </div>
 
-            <div class="etims-stat-card">
-              <div class="etims-stat-header">Total Values</div>
+            <div class="etims-stat-card border-credit">
+              <div class="etims-stat-header header-credit">Total Values</div>
               <div class="etims-stat-body">
                 <div class="etims-compare-row"><span class="etims-compare-label">System Total</span><span class="etims-compare-value erp">${fmt(data.metrics?.erp?.erp_net_gross)}</span></div>
                 <div class="etims-compare-row"><span class="etims-compare-label">eTIMS Total</span><span class="etims-compare-value etims">${fmt(data.metrics?.etims?.etims_net_gross)}</span></div>
@@ -357,17 +383,20 @@ async function fetchAndRenderSummary(frm, activeSetting, eligibilityData) {
   }
 }
 
-function buildTransactionTableHtml(details, fmt) {
-  const badge = (ok) =>
-    ok
-      ? `<span class="etims-pill etims-pill-success">${ETIMS_ICONS.check} Signed</span>`
-      : `<span class="etims-pill etims-pill-danger">${ETIMS_ICONS.x} Unsigned</span>`;
+function buildTransactionTableHtml(details, fmt, currentDocName, settingsDoc) {
+  const badge = (ok, isCurrent) => {
+    if (!ok) {
+      return `<span class="etims-pill etims-pill-danger ${isCurrent ? "pulse-border" : ""}">${ETIMS_ICONS.x} Unsigned</span>`;
+    }
+    return `<span class="etims-pill etims-pill-success">${ETIMS_ICONS.check} Signed</span>`;
+  };
 
   const rowsHtml = details.length
     ? details
         .map((row, i) => {
           const isInvoice = row.type === "Sales Invoice";
           const isCredit = row.type === "Credit Note";
+          const isCurrent = row.reference_number === currentDocName;
           const bannerType = row.row_status || "neutral";
           const statusText = row.status_message || "Active Trace Baseline";
           const actionText = row.action_message || "Metrics aligned cleanly.";
@@ -375,6 +404,7 @@ function buildTransactionTableHtml(details, fmt) {
           let bgStyle =
             "background: rgba(107,114,128,0.06); border: 1px solid rgba(107,114,128,0.2);";
           let labelColor = "#475569";
+
           if (bannerType === "success") {
             bgStyle =
               "background: rgba(16,185,129,0.06); border: 1px solid rgba(16,185,129,0.18);";
@@ -403,18 +433,55 @@ function buildTransactionTableHtml(details, fmt) {
             ? frappe.datetime.str_to_user(row.scu_receipt_date)
             : "—";
 
+          let typeChipClass = "etims-type-chip";
+          if (isCredit) {
+            typeChipClass += " chip-credit";
+          } else if (isInvoice) {
+            typeChipClass += " chip-invoice";
+          }
+
+          let rowClass = i % 2 === 0 ? "row-even" : "row-odd";
+          if (isCurrent) {
+            rowClass += " row-highlight-current";
+          } else if (!row.is_signed) {
+            rowClass += " row-highlight-unsigned";
+          } else if (bannerType === "danger") {
+            rowClass += " row-highlight-wrong";
+          }
+
+          let targetLinkUrl = "";
+          if (settingsDoc && settingsDoc.enable_verification_redirect == 1) {
+            const key = currentDocName.replace(/[-:\s]/g, "").replace(".", "");
+            targetLinkUrl = `/invoice-verification?id=${encodeURIComponent(currentDocName)}&key=${encodeURIComponent(key)}`;
+          } else if (row.etims_qr_code_url) {
+            targetLinkUrl = row.etims_qr_code_url;
+          }
+
+          const portalLinkHtml = targetLinkUrl
+            ? `
+              <div class="scu-qr-action" style="margin-top: 12px; display: flex; justify-content: flex-start;">
+                <a href="${targetLinkUrl}" target="_blank" class="btn btn-xs btn-default" style="font-size:11px;font-weight:600;display:inline-flex;align-items:center;gap:4px;">
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14L21 3"/></svg> Verify via KRA Portal
+                </a>
+              </div>
+            `
+            : "";
+
           return `
-            <tr class="${i % 2 === 0 ? "row-even" : "row-odd"}">
-              <td class="muted">${frappe.datetime.str_to_user(row.invoice_date)}</td>
+            <tr class="${rowClass}">
+              <td class="muted">
+                ${isCurrent ? `<span class="current-indicator-dot"></span>` : ""}
+                ${frappe.datetime.str_to_user(row.invoice_date)}
+              </td>
               <td class="bold">${frappe.utils.escape_html(row.customer || "—")}</td>
-              <td><span class="etims-type-chip">${row.type || "—"}</span></td>
+              <td><span class="${typeChipClass}">${row.type || "—"} ${isCurrent ? " (Current)" : ""}</span></td>
               <td class="r mono">${isInvoice ? fmt(row.amount) : "—"}</td>
               <td class="r mono" style="color:var(--text-muted);">${isCredit ? fmt(row.amount) : "—"}</td>
               <td class="r mono" style="color:var(--text-muted);">${fmt(row.tax)}</td>
-              <td class="muted" style="font-family:monospace;font-size:11px;">${frappe.utils.escape_html(row.reference_number || "—")}</td>
-              <td class="c">${badge(row.is_signed)}</td>
+              <td class="muted text-ellipsis-ref" style="font-family:monospace;font-size:11px;">${frappe.utils.escape_html(row.reference_number || "—")}</td>
+              <td class="c">${badge(row.is_signed, isCurrent)}</td>
             </tr>
-            <tr class="${i % 2 === 0 ? "row-even" : "row-odd"} data-scu-row">
+            <tr class="${rowClass} data-scu-row">
               <td colspan="8" style="padding: 0px 16px 14px 16px;">
                 <div class="scu-details-enhanced">
                   <div class="scu-grid-layout">
@@ -452,17 +519,7 @@ function buildTransactionTableHtml(details, fmt) {
                     </div>
                   </div>
                   
-                  ${
-                    row.etims_qr_code_url
-                      ? `
-                    <div class="scu-qr-action" style="margin-top: 12px; display: flex; justify-content: flex-start;">
-                      <a href="${row.etims_qr_code_url}" target="_blank" class="btn btn-xs btn-default" style="font-size:11px;font-weight:600;display:inline-flex;align-items:center;gap:4px;">
-                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14L21 3"/></svg> Verify via KRA Portal
-                      </a>
-                    </div>
-                  `
-                      : ""
-                  }
+                  ${portalLinkHtml}
                   ${noteContextHtml}
                 </div>
               </td>
@@ -610,12 +667,12 @@ function renderSummaryDashboard(htmlField, data) {
           </div>
         </div>
 
-        <div class="etims-stat-card">
-          <div class="etims-stat-header">Credit Notes</div>
+        <div class="etims-stat-card border-credit-subtle">
+          <div class="etims-stat-header header-credit-subtle">Credit Notes</div>
           <div class="etims-stat-body">
-            <div class="etims-compare-row"><span class="etims-compare-label">System Baseline</span><span class="etims-compare-value erp">${data.fmt(data.erpCreditAmount)}</span></div>
-            <div class="etims-compare-row"><span class="etims-compare-label">eTIMS</span><span class="etims-compare-value etims">${data.fmt(data.etimsCreditAmount)}</span></div>
-            <div class="etims-diff-section">
+            <div class="etims-compare-row"><span class="etims-compare-label">System Baseline</span><span class="etims-compare-value erp-credit">${data.fmt(data.erpCreditAmount)}</span></div>
+            <div class="etims-compare-row"><span class="etims-compare-label">eTIMS</span><span class="etims-compare-value etims-credit">${data.fmt(data.etimsCreditAmount)}</span></div>
+            <div class="etims-diff-section" style="border-top-style: dotted;">
               <div class="etims-diff-row"><span class="etims-diff-label">Difference</span><span class="etims-diff-amount ${data.creditDifference >= 0 ? "positive" : "negative"}">${data.fmt(data.creditDifference)}</span></div>
               <div class="etims-diff-row"><span class="etims-diff-label">Difference %</span><div><span class="etims-diff-percent" style="font-size:13px;font-weight:700;">${data.creditDiffPercent.toFixed(2)}%</span></div></div>
             </div>
@@ -667,7 +724,7 @@ function renderErrorBlock(htmlField) {
   `);
 }
 
-function addCustomButtons(frm, activeSetting, summaryData) {
+function addCustomButtons(frm, activeSetting, summaryData, settingsDoc) {
   if (frm.doc.docstatus === 0 || frm.doc.prevent_etims_submission) return;
 
   if (!frm.doc.sent_to_etims) {
@@ -740,17 +797,30 @@ function addCustomButtons(frm, activeSetting, summaryData) {
     __("eTims Actions"),
   );
 
-  frm.add_custom_button(
-    __("View Invoice Status"),
-    () => {
-      const key = frm.doc.creation.replace(/[-:\s]/g, "").replace(".", "");
-      window.open(
-        `/invoice-verification?id=${encodeURIComponent(frm.doc.name)}&key=${encodeURIComponent(key)}`,
-        "_blank",
-      );
-    },
-    __("eTims Actions"),
-  );
+  let showVerificationBtn = false;
+  let targetActionUrl = "";
+
+  if (settingsDoc && settingsDoc.enable_verification_redirect == 1) {
+    showVerificationBtn = true;
+    const key = frm.doc.creation.replace(/[-:\s]/g, "").replace(".", "");
+    targetActionUrl = `/invoice-verification?id=${encodeURIComponent(frm.doc.name)}&key=${encodeURIComponent(key)}`;
+  } else if (frm.doc.etims_qr_code_url) {
+    showVerificationBtn = true;
+    targetActionUrl = frm.doc.etims_qr_code_url;
+    frm.toggle_display("etims_verification_url", false);
+  } else {
+    frm.toggle_display("etims_verification_url", false);
+  }
+
+  if (showVerificationBtn && targetActionUrl) {
+    frm.add_custom_button(
+      __("View Invoice Status"),
+      () => {
+        window.open(targetActionUrl, "_blank");
+      },
+      __("eTims Actions"),
+    );
+  }
 
   if (frm.doc.sent_to_etims && summaryData?.hasSignificantMismatch) {
     frm.add_custom_button(
@@ -812,9 +882,6 @@ async function regenerateQRCode(frm, activeSetting) {
                   <div style="color: #78350f;">
                     <strong>Reason:</strong> ${invoiceResult.message}
                   </div>
-                  <div style="margin-top: 8px; padding: 8px 12px; background: #fef3c7; border-radius: 4px; font-size: 13px;">
-                    ${__("No verification URL found. Please ensure the invoice has been submitted to eTIMS first.")}
-                  </div>
                 </div>
               `,
               });
@@ -829,9 +896,6 @@ async function regenerateQRCode(frm, activeSetting) {
                   </div>
                   <div style="color: #7f1d1d;">
                     <strong>Error:</strong> ${invoiceResult.message}
-                  </div>
-                  <div style="margin-top: 8px; padding: 8px 12px; background: #fee2e2; border-radius: 4px; font-size: 13px;">
-                    ${__("Please check the logs or contact support if the issue persists.")}
                   </div>
                 </div>
               `,
@@ -851,9 +915,6 @@ async function regenerateQRCode(frm, activeSetting) {
               </div>
               <div style="color: #7f1d1d;">
                 <strong>Error:</strong> ${err.message || err}
-              </div>
-              <div style="margin-top: 8px; padding: 8px 12px; background: #fee2e2; border-radius: 4px; font-size: 13px;">
-                ${__("An unexpected error occurred. Please try again or contact support.")}
               </div>
             </div>
           `,
@@ -958,17 +1019,17 @@ function showCorrectionDialog(frm, activeSetting, summaryData) {
                 <div style="font-size:11px;color:#64748b;font-weight:600;text-transform:uppercase;">System Gross Invoice</div>
                 <div style="margin-top:6px;font-size:20px;font-weight:700;color:#0f172a;font-family:monospace;">${formatValue(erpInvoiceAmount)}</div>
               </div>
-              <div style="padding:14px;border-radius:10px;border:1px solid #e2e8f0;background:#ffffff;">
-                <div style="font-size:11px;color:#64748b;font-weight:600;text-transform:uppercase;">System Returns Applied</div>
-                <div style="margin-top:6px;font-size:20px;font-weight:700;color:#0f172a;font-family:monospace;">${formatValue(erpCreditAmount)}</div>
+              <div style="padding:14px;border-radius:10px;border:1px solid #b2c5d9;background:#f1f5f9;">
+                <div style="font-size:11px;color:#475569;font-weight:600;text-transform:uppercase;">System Returns Applied</div>
+                <div style="margin-top:6px;font-size:20px;font-weight:700;color:#1e293b;font-family:monospace;">${formatValue(erpCreditAmount)}</div>
               </div>
               <div style="padding:14px;border-radius:10px;border:1px solid #bfdbfe;background:#eff6ff;">
                 <div style="font-size:11px;color:#1d4ed8;font-weight:600;text-transform:uppercase;">eTIMS Registered Gross</div>
                 <div style="margin-top:6px;font-size:20px;font-weight:700;color:#1e3a8a;font-family:monospace;">${formatValue(etimsInvoiceAmount)}</div>
               </div>
-              <div style="padding:14px;border-radius:10px;border:1px solid #bfdbfe;background:#eff6ff;">
-                <div style="font-size:11px;color:#1d4ed8;font-weight:600;text-transform:uppercase;">eTIMS Credit Trace</div>
-                <div style="margin-top:6px;font-size:20px;font-weight:700;color:#1e3a8a;font-family:monospace;">${formatValue(etimsCreditAmount)}</div>
+              <div style="padding:14px;border-radius:10px;border:1px solid #cbd5e1;background:#f8fafc;">
+                <div style="font-size:11px;color:#64748b;font-weight:600;text-transform:uppercase;">eTIMS Credit Trace</div>
+                <div style="margin-top:6px;font-size:20px;font-weight:700;color:#334155;font-family:monospace;">${formatValue(etimsCreditAmount)}</div>
               </div>
               <div style="padding:14px;border-radius:10px;border:1px solid #e5e7eb;background:#ffffff;">
                 <div style="font-size:11px;color:#475569;font-weight:600;text-transform:uppercase;">System Core Balance</div>
@@ -1258,6 +1319,10 @@ const SHARED_ETIMS_STYLES = `
       flex-wrap: wrap;
       gap: 16px;
     }
+    .etims-hero.theme-credit {
+      background: linear-gradient(135deg, rgba(71, 85, 105, 0.07) 0%, var(--card-bg) 100%);
+      border-color: rgba(71, 85, 105, 0.3);
+    }
     .etims-hero-title {
       font-size: 14px;
       font-weight: 800;
@@ -1307,6 +1372,12 @@ const SHARED_ETIMS_STYLES = `
       overflow: hidden;
       transition: transform 0.2s ease, box-shadow 0.2s ease;
     }
+    .etims-stat-card.border-credit {
+      border-color: rgba(71, 85, 105, 0.4);
+    }
+    .etims-stat-card.border-credit-subtle {
+      border-color: rgba(71, 85, 105, 0.25);
+    }
     .etims-stat-card:hover {
       transform: translateY(-2px);
       box-shadow: 0 8px 16px rgba(0,0,0,0.1);
@@ -1322,6 +1393,14 @@ const SHARED_ETIMS_STYLES = `
       font-size: 13px;
       text-transform: uppercase;
       letter-spacing: 0.05em;
+      color: var(--text-muted);
+    }
+    .etims-stat-header.header-credit {
+      background: rgba(71, 85, 105, 0.08);
+      color: #475569;
+    }
+    .etims-stat-header.header-credit-subtle {
+      background: rgba(71, 85, 105, 0.03);
       color: var(--text-muted);
     }
     .etims-stat-body {
@@ -1355,8 +1434,12 @@ const SHARED_ETIMS_STYLES = `
     }
     .etims-compare-value.erp { color: #3b82f6; }
     .etims-compare-value.etims { color: #10b981; }
+    .etims-compare-value.erp-credit { color: #64748b; }
+    .etims-compare-value.etims-credit { color: #475569; }
     html[data-theme="dark"] .etims-compare-value.erp { color: #60a5fa; }
     html[data-theme="dark"] .etims-compare-value.etims { color: #34d399; }
+    html[data-theme="dark"] .etims-compare-value.erp-credit { color: #94a3b8; }
+    html[data-theme="dark"] .etims-compare-value.etims-credit { color: #cbd5e1; }
     
     .etims-diff-section {
       margin-top: 16px;
@@ -1438,6 +1521,27 @@ const SHARED_ETIMS_STYLES = `
     html[data-theme="dark"] .etims-table tbody tr:hover { background: rgba(107,114,128,0.2) !important; }
     .etims-table tbody tr.row-even { background: var(--card-bg); }
     .etims-table tbody tr.row-odd  { background: var(--disabled-bg, var(--control-bg)); }
+    
+    .etims-table tbody tr.row-highlight-current {
+      background: rgba(59, 130, 246, 0.06) !important;
+    }
+    .etims-table tbody tr.row-highlight-unsigned {
+      background: rgba(239, 68, 68, 0.04) !important;
+    }
+    .etims-table tbody tr.row-highlight-wrong {
+      background: rgba(245, 158, 11, 0.04) !important;
+    }
+    
+    .current-indicator-dot {
+      display: inline-block;
+      width: 7px;
+      height: 7px;
+      background-color: #3b82f6;
+      border-radius: 50%;
+      margin-right: 5px;
+      vertical-align: middle;
+    }
+    
     .etims-table td {
       padding: 12px 16px;
       color: var(--text-color);
@@ -1450,6 +1554,13 @@ const SHARED_ETIMS_STYLES = `
     }
     .etims-table td.muted { color: var(--text-muted); font-size: 12px; }
     .etims-table td.bold  { font-weight: 700; color: var(--heading-color, var(--text-color)); }
+    .etims-table td.text-ellipsis-ref {
+      max-width: 140px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    
     .etims-type-chip {
       display: inline-block;
       padding: 3px 10px;
@@ -1462,13 +1573,30 @@ const SHARED_ETIMS_STYLES = `
       color: var(--gray-700, var(--text-muted));
       border: 1px solid var(--gray-200, var(--border-color));
     }
+    .etims-type-chip.chip-invoice {
+      background: rgba(59, 130, 246, 0.12);
+      color: #1e40af;
+      border-color: rgba(59, 130, 246, 0.25);
+    }
+    .etims-type-chip.chip-credit {
+      background: rgba(71, 85, 105, 0.12);
+      color: #334155;
+      border-color: rgba(71, 85, 105, 0.25);
+    }
     html[data-theme="dark"] .etims-type-chip {
       background: rgba(107,114,128,0.2);
       color: #9ca3af;
       border-color: rgba(107,114,128,0.3);
     }
+    html[data-theme="dark"] .etims-type-chip.chip-invoice {
+      background: rgba(59, 130, 246, 0.2);
+      color: #93c5fd;
+    }
+    html[data-theme="dark"] .etims-type-chip.chip-credit {
+      background: rgba(148, 163, 184, 0.2);
+      color: #cbd5e1;
+    }
 
-    /* Enhanced Structuring for SCU Details Metadata Pane */
     .scu-details-enhanced {
       background: var(--navbar-bg, var(--panel-bg, var(--control-bg)));
       border: 1px solid var(--border-color);
@@ -1666,6 +1794,17 @@ const SHARED_ETIMS_STYLES = `
       animation: etims-spin 0.75s linear infinite;
       margin: 0 auto 16px;
     }
+    
+    .pulse-border {
+      box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.4);
+      animation: pulse-danger 1.5s infinite;
+    }
+    @keyframes pulse-danger {
+      0% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.4); }
+      70% { box-shadow: 0 0 0 5px rgba(239, 68, 68, 0); }
+      100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0); }
+    }
+    
     @keyframes etims-spin { to { transform: rotate(360deg); } }
     @keyframes etims-fade { from { opacity:0; transform: translateY(8px); } to { opacity:1; transform: translateY(0); } }
     .etims-root { animation: etims-fade 0.3s ease; }

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/customer.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/customer.py
@@ -26,31 +26,31 @@ def validate(doc: Document, method: str = None) -> None:
 
     validate_kra_pin(tax_id)
 
-    tax_id_lower = tax_id.lower()
+    # tax_id_lower = tax_id.lower()
 
-    existing = frappe.get_all(
-        "Customer",
-        filters={
-            "name": ["!=", doc.name or ""],
-            "tax_id": ["like", tax_id_lower],
-        },
-        fields=["name", "tax_id"],
-        limit_page_length=1,
-    )
+    # existing = frappe.get_all(
+    #     "Customer",
+    #     filters={
+    #         "name": ["!=", doc.name or ""],
+    #         "tax_id": ["like", tax_id_lower],
+    #     },
+    #     fields=["name", "tax_id"],
+    #     limit_page_length=1,
+    # )
 
-    existing = [c for c in existing if (c.get("tax_id") or "").lower() == tax_id_lower]
+    # existing = [c for c in existing if (c.get("tax_id") or "").lower() == tax_id_lower]
 
-    if existing:
-        links = ", ".join(
-            f'<a href="/app/customer/{c.get("name")}" target="_blank">{c.get("name")}</a>'
-            for c in existing
-        )
-        frappe.throw(
-            f"""
-            Tax ID <strong>{tax_id}</strong> is already used by Customer(s) {links}.
-            """,
-            title="Duplicate Tax ID",
-        )
+    # if existing:
+    #     links = ", ".join(
+    #         f'<a href="/app/customer/{c.get("name")}" target="_blank">{c.get("name")}</a>'
+    #         for c in existing
+    #     )
+    #     frappe.throw(
+    #         f"""
+    #         Tax ID <strong>{tax_id}</strong> is already used by Customer(s) {links}.
+    #         """,
+    #         title="Duplicate Tax ID",
+    #     )
 
 
 def submit_details(doc: Document) -> None:

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/sales_invoice.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/sales_invoice.py
@@ -166,15 +166,32 @@ def get_single_invoice_reconciliation(invoice_name):
 
 
 def _get_erp_metrics(invoice, company_currency):
-    if invoice.currency == "KES":
-        invoice_amount = flt(invoice.grand_total)
-        invoice_tax = flt(invoice.total_taxes_and_charges)
+    currency = invoice.currency
+    conversion_rate = 1
+    gross_field, tax_field = "grand_total", "total_taxes_and_charges"
+
+    if currency == "KES":
+        gross_field = "grand_total"
+        tax_field = "total_taxes_and_charges"
     elif company_currency == "KES":
-        invoice_amount = flt(invoice.base_grand_total)
-        invoice_tax = flt(invoice.base_total_taxes_and_charges)
+        gross_field = "base_grand_total"
+        tax_field = "base_total_taxes_and_charges"
     else:
-        invoice_amount = flt(invoice.grand_total)
-        invoice_tax = flt(invoice.total_taxes_and_charges)
+        conversion_rate, used_rate = get_kes_conversion_rate(
+            currency=currency,
+            company_currency=company_currency,
+            posting_date=invoice.posting_date,
+        )
+        if used_rate != "net":
+            gross_field = "base_grand_total"
+            tax_field = "base_total_taxes_and_charges"
+
+    invoice_amount = flt(invoice.get(gross_field))
+    invoice_tax = flt(invoice.get(tax_field))
+
+    if gross_field == "grand_total" and conversion_rate != 1:
+        invoice_amount *= conversion_rate
+        invoice_tax *= conversion_rate
 
     credit_notes = frappe.get_all(
         "Sales Invoice",
@@ -192,23 +209,43 @@ def _get_erp_metrics(invoice, company_currency):
     total_erp_credit_tax = 0
 
     for cn in credit_notes:
-        if cn.currency == "KES":
-            total_erp_credit += flt(cn.grand_total)
-            total_erp_credit_tax += flt(cn.total_taxes_and_charges)
+        cn_currency = cn.currency
+        cn_conversion_rate = 1
+        cn_gross_field, cn_tax_field = "grand_total", "total_taxes_and_charges"
+
+        if cn_currency == "KES":
+            cn_gross_field = "grand_total"
+            cn_tax_field = "total_taxes_and_charges"
         elif company_currency == "KES":
-            total_erp_credit += flt(cn.base_grand_total)
-            total_erp_credit_tax += flt(cn.base_total_taxes_and_charges)
+            cn_gross_field = "base_grand_total"
+            cn_tax_field = "base_total_taxes_and_charges"
         else:
-            total_erp_credit += flt(cn.grand_total)
-            total_erp_credit_tax += flt(cn.total_taxes_and_charges)
+            cn_conversion_rate, cn_used_rate = get_kes_conversion_rate(
+                currency=cn_currency,
+                company_currency=company_currency,
+                posting_date=invoice.posting_date,
+            )
+            if cn_used_rate != "net":
+                cn_gross_field = "base_grand_total"
+                cn_tax_field = "base_total_taxes_and_charges"
+
+        cn_amt = flt(cn.get(cn_gross_field))
+        cn_tx = flt(cn.get(cn_tax_field))
+
+        if cn_gross_field == "grand_total" and cn_conversion_rate != 1:
+            cn_amt *= cn_conversion_rate
+            cn_tx *= cn_conversion_rate
+
+        total_erp_credit -= abs(cn_amt)
+        total_erp_credit_tax -= abs(cn_tx)
 
     return {
         "erp_invoice_gross": invoice_amount,
         "erp_invoice_tax": invoice_tax,
         "erp_credit_gross": total_erp_credit,
         "erp_credit_tax": total_erp_credit_tax,
-        "erp_net_gross": invoice_amount - total_erp_credit,
-        "erp_net_tax": invoice_tax - total_erp_credit_tax,
+        "erp_net_gross": invoice_amount + total_erp_credit,
+        "erp_net_tax": invoice_tax + total_erp_credit_tax,
     }
 
 
@@ -261,9 +298,13 @@ def _get_sequential_etims_data(invoice, references):
         if is_invoice:
             etims_invoice_gross += amt
             etims_invoice_tax += tax
+            display_amt = amt
+            display_tax = tax
         else:
-            etims_credit_gross += abs(amt)
-            etims_credit_tax += abs(tax)
+            etims_credit_gross -= abs(amt)
+            etims_credit_tax -= abs(tax)
+            display_amt = -abs(amt)
+            display_tax = -abs(tax)
 
         details.append(
             {
@@ -283,8 +324,8 @@ def _get_sequential_etims_data(invoice, references):
                 "scu_internal_data": entry.scu_internal_data,
                 "etims_qr_code_url": entry.etims_qr_code_url,
                 "is_signed": entry.is_signed,
-                "amount": amt if is_invoice else -abs(amt),
-                "tax": tax if is_invoice else -abs(tax),
+                "amount": display_amt,
+                "tax": display_tax,
                 "has_returns": False,
             }
         )
@@ -303,8 +344,8 @@ def _get_sequential_etims_data(invoice, references):
         "etims_invoice_tax": etims_invoice_tax,
         "etims_credit_gross": etims_credit_gross,
         "etims_credit_tax": etims_credit_tax,
-        "etims_net_gross": etims_invoice_gross - etims_credit_gross,
-        "etims_net_tax": etims_invoice_tax - etims_credit_tax,
+        "etims_net_gross": etims_invoice_gross + etims_credit_gross,
+        "etims_net_tax": etims_invoice_tax + etims_credit_tax,
     }
 
 

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/sales_invoice.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/sales_invoice.py
@@ -7,6 +7,7 @@ from ...utils import (
     apply_item_taxes_and_codes,
     build_verification_url,
     generate_and_attach_qr_code,
+    get_kes_conversion_rate,
     get_settings,
 )
 from .shared_overrides import generic_invoices_on_submit_override
@@ -75,39 +76,57 @@ def regenerate_qr_code(names):
     for name in names:
         try:
             doc = frappe.get_doc("Sales Invoice", name)
+            settings_doc = get_settings(company_name=doc.company)
 
-            etims_verification_url = build_verification_url(doc)
-
-            if etims_verification_url:
-                doc.db_set(
-                    "etims_verification_url",
-                    etims_verification_url,
-                    update_modified=False,
-                )
-
-                etims_qr_image = generate_and_attach_qr_code(
-                    etims_verification_url, name, doc.doctype
-                )
-
-                doc.db_set("etims_qr_image", etims_qr_image, update_modified=False)
-
-                frappe.db.commit()
-
+            if doc.sent_to_etims == 0:
                 results.append(
                     {
                         "invoice": name,
-                        "status": "success",
-                        "message": "Verification URL and QR Code regenerated successfully",
+                        "status": "skipped",
+                        "message": "Invoice has not been submitted to eTIMS yet",
                     }
                 )
+            etims_qr_image = None
+
+            if settings_doc.enable_verification_redirect:
+                etims_verification_url = build_verification_url(doc)
+
+                if etims_verification_url:
+                    doc.db_set(
+                        "etims_verification_url",
+                        etims_verification_url,
+                        update_modified=False,
+                    )
+
+                    etims_qr_image = generate_and_attach_qr_code(
+                        etims_verification_url, name, doc.doctype
+                    )
+            elif doc.etims_qr_code_url:
+                etims_qr_image = generate_and_attach_qr_code(
+                    doc.etims_qr_code_url, name, doc.doctype
+                )
+
             else:
                 results.append(
                     {
                         "invoice": name,
                         "status": "skipped",
-                        "message": "Unable to build verification URL",
+                        "message": "No verification URL or QR code available for this invoice",
                     }
                 )
+                continue
+
+            doc.db_set("etims_qr_image", etims_qr_image, update_modified=False)
+
+            frappe.db.commit()
+
+            results.append(
+                {
+                    "invoice": name,
+                    "status": "success",
+                    "message": "Verification URL and QR Code regenerated successfully",
+                }
+            )
 
         except Exception as e:
             frappe.db.rollback()

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/shared_overrides.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/overrides/server/shared_overrides.py
@@ -75,7 +75,10 @@ def generic_invoices_on_submit_override(
 
     updates = {}
 
-    if not doc.get("etims_verification_url"):
+    if (
+        not doc.get("etims_verification_url")
+        and settings_doc.enable_verification_redirect
+    ):
         updates["etims_verification_url"] = build_verification_url(doc)
 
     current_verification_url = updates.get("etims_verification_url") or doc.get(
@@ -115,6 +118,7 @@ def generic_invoices_on_submit_override(
             doctype=invoice_type,
             document_name=doc.name,
             settings_name=settings_doc.name,
+            company=company_name,
         )
 
     else:
@@ -208,8 +212,13 @@ def validate(doc: "Document", method: str) -> None:
 def before_submit(doc: Document, method: str) -> None:
     if doc.doctype == "Sales Invoice":
         response = analyze_etims_eligibility(doc.name)
+        settings_doc = get_settings(company_name=doc.company)
 
-        if response.get("eligible"):
+        if (
+            response.get("eligible")
+            and settings_doc
+            and settings_doc.enable_verification_redirect
+        ):
             url = build_verification_url(doc)
 
             if not doc.get("etims_verification_url"):

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -829,7 +829,13 @@ def after_save_(doc: "Document", method: str | None = None) -> None:
     if doc.doctype == "Sales Invoice":
         response = analyze_etims_eligibility(doc.name)
 
-        if response.get("eligible"):
+        settings_doc = get_settings(company_name=doc.company)
+
+        if (
+            response.get("eligible")
+            and settings_doc
+            and settings_doc.enable_verification_redirect
+        ):
             url = build_verification_url(doc)
 
             if not doc.get("etims_verification_url"):
@@ -2233,6 +2239,11 @@ def clean_url_params(url: str) -> str:
 def update_sales_invoice_etims_details(name: str) -> None:
     sales_invoice = frappe.get_doc("Sales Invoice", name)
 
+    settings_doc = get_settings(company_name=sales_invoice.company)
+    enable_verification_redirect = (
+        settings_doc.enable_verification_redirect if settings_doc else False
+    )
+
     return_invoices = frappe.get_all(
         "Sales Invoice",
         filters={"return_against": sales_invoice.name, "docstatus": 1, "is_return": 1},
@@ -2267,8 +2278,8 @@ def update_sales_invoice_etims_details(name: str) -> None:
         "etims_qr_code_url": None,
         "etims_id": None,
         "sent_to_etims": 0,
-        "etims_verification_url": sales_invoice.get("etims_verification_url"),
-        "etims_qr_image": sales_invoice.get("etims_qr_image"),
+        "etims_verification_url": None,
+        "etims_qr_image": None,
     }
 
     if ledgers:
@@ -2342,13 +2353,21 @@ def update_sales_invoice_etims_details(name: str) -> None:
             }
         )
 
-    if not updates["etims_verification_url"]:
-        updates["etims_verification_url"] = build_verification_url(sales_invoice)
+    if enable_verification_redirect:
+        if not updates["etims_verification_url"]:
+            updates["etims_verification_url"] = build_verification_url(sales_invoice)
 
-    if not updates["etims_qr_image"] and updates["etims_verification_url"]:
-        updates["etims_qr_image"] = generate_and_attach_qr_code(
-            updates["etims_verification_url"], sales_invoice.name, sales_invoice.doctype
-        )
+        if not updates["etims_qr_image"] and updates["etims_verification_url"]:
+            updates["etims_qr_image"] = generate_and_attach_qr_code(
+                updates["etims_verification_url"],
+                sales_invoice.name,
+                sales_invoice.doctype,
+            )
+    else:
+        if not updates["etims_qr_image"] and updates["etims_qr_code_url"]:
+            updates["etims_qr_image"] = generate_and_attach_qr_code(
+                updates["etims_qr_code_url"], sales_invoice.name, sales_invoice.doctype
+            )
 
     sales_invoice.db_set(updates, update_modified=False)
 

--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/workspace/etims_integration/etims_integration.json
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/workspace/etims_integration/etims_integration.json
@@ -1,6 +1,6 @@
 {
  "charts": [],
- "content": "[{\"id\":\"Sdc1m9AyDb\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">eTims Integration</span>\",\"col\":12}},{\"id\":\"dPft27k0bT\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"eTims Notice\",\"col\":3}},{\"id\":\"IJhA6ryFMf\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Integration Request\",\"col\":3}},{\"id\":\"P-6Iw_P1zg\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Error Log\",\"col\":3}},{\"id\":\"btwAd12hX1\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"eTims Settings\",\"col\":3}},{\"id\":\"n0_etvXkCr\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"eTims Dashboard\",\"col\":3}},{\"id\":\"2mBJcIyECW\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Detailed Documentation\",\"col\":3}},{\"id\":\"UEeD0TQZ1M\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"wDRcmffW60\",\"type\":\"card\",\"data\":{\"card_name\":\"Masters\",\"col\":4}},{\"id\":\"BWUEC2YYZG\",\"type\":\"card\",\"data\":{\"card_name\":\"Setup and Configurations\",\"col\":4}},{\"id\":\"1uTnc5NfCF\",\"type\":\"card\",\"data\":{\"card_name\":\"Codes\",\"col\":4}},{\"id\":\"vct65zYsQ1\",\"type\":\"card\",\"data\":{\"card_name\":\"Item Information\",\"col\":4}},{\"id\":\"RClRPl22Jw\",\"type\":\"card\",\"data\":{\"card_name\":\"Logs and Troubleshooting\",\"col\":4}},{\"id\":\"-1FtcpP1Od\",\"type\":\"card\",\"data\":{\"card_name\":\"Reports\",\"col\":4}},{\"id\":\"uCoSow52Yf\",\"type\":\"card\",\"data\":{\"card_name\":\"Purchases\",\"col\":4}},{\"id\":\"jAshTaCV2Q\",\"type\":\"card\",\"data\":{\"card_name\":\"Ledgers\",\"col\":4}}]",
+ "content": "[{\"id\":\"Sdc1m9AyDb\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">eTims Integration</span>\",\"col\":12}},{\"id\":\"dPft27k0bT\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"eTims Notice\",\"col\":3}},{\"id\":\"IJhA6ryFMf\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Integration Request\",\"col\":3}},{\"id\":\"P-6Iw_P1zg\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Error Log\",\"col\":3}},{\"id\":\"btwAd12hX1\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"eTims Settings\",\"col\":3}},{\"id\":\"n0_etvXkCr\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"eTims Dashboard\",\"col\":3}},{\"id\":\"2mBJcIyECW\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Detailed Documentation\",\"col\":3}},{\"id\":\"UEeD0TQZ1M\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"wDRcmffW60\",\"type\":\"card\",\"data\":{\"card_name\":\"Masters\",\"col\":4}},{\"id\":\"BWUEC2YYZG\",\"type\":\"card\",\"data\":{\"card_name\":\"Setup and Configurations\",\"col\":4}},{\"id\":\"1uTnc5NfCF\",\"type\":\"card\",\"data\":{\"card_name\":\"Codes\",\"col\":4}},{\"id\":\"vct65zYsQ1\",\"type\":\"card\",\"data\":{\"card_name\":\"Item Information\",\"col\":4}},{\"id\":\"RClRPl22Jw\",\"type\":\"card\",\"data\":{\"card_name\":\"Logs and Troubleshooting\",\"col\":4}},{\"id\":\"-1FtcpP1Od\",\"type\":\"card\",\"data\":{\"card_name\":\"Reports\",\"col\":4}},{\"id\":\"jAshTaCV2Q\",\"type\":\"card\",\"data\":{\"card_name\":\"Ledgers\",\"col\":4}}]",
  "creation": "2024-04-03 10:47:58.925837",
  "custom_blocks": [],
  "docstatus": 0,
@@ -16,148 +16,9 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Purchases",
-   "link_count": 1,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "eTims Registered Purchase",
-   "link_count": 0,
-   "link_to": "Navari eTims Registered Purchases",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "description": "These DocTypes hold error logs to assist in troubleshooting and debugging",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Logs and Troubleshooting",
-   "link_count": 4,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Scheduled Job",
-   "link_count": 0,
-   "link_to": "Scheduled Job Type",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Integration Request",
-   "link_count": 0,
-   "link_to": "Integration Request",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Background Job",
-   "link_count": 0,
-   "link_to": "RQ Job",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Error Log",
-   "link_count": 0,
-   "link_to": "Error Log",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
    "label": "eTims Stock Operation Type",
    "link_count": 0,
    "link_to": "Navari eTims Stock Operation Type",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "description": "DocTypes required to setup and configure the integration",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Setup and Configurations",
-   "link_count": 6,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "eTims Settings",
-   "link_count": 0,
-   "link_to": "Navari KRA eTims Settings",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Routes Reference",
-   "link_count": 0,
-   "link_to": "Navari eTims Routes",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Company",
-   "link_count": 0,
-   "link_to": "Company",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Branch",
-   "link_count": 0,
-   "link_to": "Branch",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Department",
-   "link_count": 0,
-   "link_to": "Department",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "eTims Workstation",
-   "link_count": 0,
-   "link_to": "Navari KRA eTims Workstation",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
@@ -254,135 +115,6 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Item Information",
-   "link_count": 5,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "eTims Item Classification",
-   "link_count": 0,
-   "link_to": "Navari KRA eTims Item Classification",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Item Tax Template",
-   "link_count": 0,
-   "link_to": "Item Tax Template",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "eTims Imported Item",
-   "link_count": 0,
-   "link_to": "Navari eTims Registered Imported Item",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "eTims Item Type",
-   "link_count": 0,
-   "link_to": "Navari eTims Item Type",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "eTims Product Type",
-   "link_count": 0,
-   "link_to": "Navari eTims Product Type",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "description": "This card enumerates codes received from eTims servers",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Codes",
-   "link_count": 6,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Mode of Payment",
-   "link_count": 0,
-   "link_to": "Mode of Payment",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "eTims Country",
-   "link_count": 0,
-   "link_to": "Navari eTims Country",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "eTims Taxation Type",
-   "link_count": 0,
-   "link_to": "Navari KRA eTims Taxation Type",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "eTims Unit of Quantity",
-   "link_count": 0,
-   "link_to": "Navari eTims Unit of Quantity",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "eTims Payment Type",
-   "link_count": 0,
-   "link_to": "Navari KRA eTims Payment Type",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "eTims Packaging Unit",
-   "link_count": 0,
-   "link_to": "Navari eTims Packaging Unit",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
    "label": "Reports",
    "link_count": 6,
    "link_type": "DocType",
@@ -467,9 +199,258 @@
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
+  },
+  {
+   "description": "DocTypes required to setup and configure the integration",
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Setup and Configurations",
+   "link_count": 6,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "eTims Settings",
+   "link_count": 0,
+   "link_to": "Navari KRA eTims Settings",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Routes Reference",
+   "link_count": 0,
+   "link_to": "eTims Routes",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Company",
+   "link_count": 0,
+   "link_to": "Company",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Branch",
+   "link_count": 0,
+   "link_to": "Branch",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Department",
+   "link_count": 0,
+   "link_to": "Department",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "eTims Workstation",
+   "link_count": 0,
+   "link_to": "Navari KRA eTims Workstation",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "description": "This card enumerates codes received from eTims servers",
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Codes",
+   "link_count": 5,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Mode of Payment",
+   "link_count": 0,
+   "link_to": "Mode of Payment",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "eTims Country",
+   "link_count": 0,
+   "link_to": "eTims Country of Origin",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "eTims Taxation Type",
+   "link_count": 0,
+   "link_to": "eTims Taxation Type",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "eTims Unit of Quantity",
+   "link_count": 0,
+   "link_to": "eTims Unit of Quantity",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "eTims Packaging Unit",
+   "link_count": 0,
+   "link_to": "eTims Packaging Unit",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Item Information",
+   "link_count": 5,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "eTims Item Classification",
+   "link_count": 0,
+   "link_to": "eTims Item Classification",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Item Tax Template",
+   "link_count": 0,
+   "link_to": "Item Tax Template",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "eTims Imported Item",
+   "link_count": 0,
+   "link_to": "eTims Registered Imported Item",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "eTims Item Type",
+   "link_count": 0,
+   "link_to": "eTims Item Type",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "eTims Product Type",
+   "link_count": 0,
+   "link_to": "eTims Product Type",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "description": "These DocTypes hold error logs to assist in troubleshooting and debugging",
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Logs and Troubleshooting",
+   "link_count": 5,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Scheduled Job",
+   "link_count": 0,
+   "link_to": "Scheduled Job Type",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Integration Request",
+   "link_count": 0,
+   "link_to": "Integration Request",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Background Job",
+   "link_count": 0,
+   "link_to": "RQ Job",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Error Log",
+   "link_count": 0,
+   "link_to": "Error Log",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "eTims Stock Operation Type",
+   "link_count": 0,
+   "link_to": "Navari eTims Stock Operation Type",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
   }
  ],
- "modified": "2026-05-07 21:58:26.637019",
+ "modified": "2026-07-02 10:45:23.203747",
  "modified_by": "Administrator",
  "module": "Kenya Compliance Via Slade",
  "name": "eTims Integration",


### PR DESCRIPTION
This pull request introduces enhancements to the eTIMS (Kenya Tax Invoice Management System) integration, focusing on improved credit note handling, more flexible QR code verification links, and UI/UX improvements for transaction summaries. The most notable changes include the addition of a new settings option to control QR code verification behavior, updates to summary and transaction table rendering for better clarity, and backend logic improvements for credit note processing.

**Settings and Verification Redirects:**

* Added a new `enable_verification_redirect` checkbox field to the `Navari KRA eTims Settings` doctype, allowing administrators to choose whether invoice QR codes point to an internal ERP verification page (with redirect to eTIMS) or directly to the eTIMS verification URL. [[1]](diffhunk://#diff-0a7236de24f62bd46891cd6b4ed896a9bf1806c0d5571dd58d734d6f7b7a784eR38) [[2]](diffhunk://#diff-0a7236de24f62bd46891cd6b4ed896a9bf1806c0d5571dd58d734d6f7b7a784eR590-R596)
* Updated the modification timestamp and structure of the settings JSON to reflect the new field.

**Credit Note and Invoice Processing Logic:**

* Improved logic in `submit_credit_note` to match returned results with the original invoice's eTIMS ID, ensuring the correct data object is used for further processing.
* Simplified branch customer details payload to always use `partner_name` and `document_name`, removing conditional logic for `tax_id`.
* Enhanced background task for fetching eTIMS sales invoices to handle return documents correctly, ensuring the search uses the original invoice when applicable.
* In the sales information submission success handler, added logic to generate and attach a QR code image only when `enable_verification_redirect` is disabled and a signature link is available.

**UI/UX Enhancements for Transaction Summaries:**

* Refactored the client-side logic to fetch the full settings document and pass it through summary and button rendering functions, enabling context-aware UI changes. [[1]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8R41-R59) [[2]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L97-R112) [[3]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L670-R727)
* Updated the transaction table and summary dashboard rendering to:
  - Highlight the current document row and unsigned/wrong-status rows.
  - Add a "Verify via KRA Portal" button, which links either to the ERP verification page or directly to the eTIMS portal based on the new settings flag.
  - Improve visual distinction for credit notes and various transaction statuses with new CSS classes and color schemes. [[1]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L157-R189) [[2]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L177-R204) [[3]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L189-R228) [[4]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L213-R240) [[5]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L360-R407) [[6]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8R436-R484) [[7]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L455-R522) [[8]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L613-R675)

These changes collectively improve both the administrative flexibility and the end-user experience when working with eTIMS-integrated sales invoices and credit notes.

**References:**  
[[1]](diffhunk://#diff-0a7236de24f62bd46891cd6b4ed896a9bf1806c0d5571dd58d734d6f7b7a784eR38) [[2]](diffhunk://#diff-0a7236de24f62bd46891cd6b4ed896a9bf1806c0d5571dd58d734d6f7b7a784eR590-R596) [[3]](diffhunk://#diff-0a7236de24f62bd46891cd6b4ed896a9bf1806c0d5571dd58d734d6f7b7a784eL600-R608) [[4]](diffhunk://#diff-37b580259bcef5f1c9ad8a0ad5983d6c5b704cc26d2a92d47857fe3f1babc5a1L1443-R1460) [[5]](diffhunk://#diff-37b580259bcef5f1c9ad8a0ad5983d6c5b704cc26d2a92d47857fe3f1babc5a1L566-R566) [[6]](diffhunk://#diff-323951094c926ff6a103f94551ce30619827d31f420fd4801029d928b5319bcaR733-L746) [[7]](diffhunk://#diff-07fa816e70125704befdf104e9a2dc83383e393842f04b759ae1ad8ea85f4633R310-R328) [[8]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8R41-R59) [[9]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L97-R112) [[10]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L670-R727) [[11]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L157-R189) [[12]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L177-R204) [[13]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L189-R228) [[14]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L213-R240) [[15]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L360-R407) [[16]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8R436-R484) [[17]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L455-R522) [[18]](diffhunk://#diff-d1508920267c531ac4ecf4b85c33e5765b4e8a0580c688f7fcfacec37218b6e8L613-R675)