### PR TITLE
Use invoice-level tax_id for buyer PIN, fallback to Customer masterfix: use invoice-level tax_id for buyer PIN, fallback to Customer master

### DIFF
--- a/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
+++ b/kenya_compliance_via_slade/kenya_compliance_via_slade/utils.py
@@ -445,12 +445,22 @@ def build_invoice_payload(invoice: Document, settings_name: str) -> dict:
     date_str = f"{invoice.posting_date} {invoice.posting_time or '00:00:00'}"
     fmt = "%Y-%m-%d %H:%M:%S.%f" if "." in date_str else "%Y-%m-%d %H:%M:%S"
     formatted_date = datetime.strptime(date_str, fmt).strftime("%Y-%m-%dT%H:%M:%SZ")
+        # Prefer a PIN set directly on the invoice (e.g. a walk-in customer's PIN
+    # captured per-transaction) and only fall back to the Customer master's
+    # PIN when the invoice itself doesn't carry one. invoice.tax_id is
+    # already KRA-PIN-validated in generic_invoices_on_submit_override/
+    # validate() before this payload is built.
+    customer_pin = (
+        (invoice.get("tax_id") or "").strip()
+        or frappe.get_value("Customer", invoice.customer, "tax_id")
+        or None
+    )
+
     payload = {
         "document_name": invoice.name,
         "reference_number": reference_number,
         "sales_type": "credit",
-        "customer_pin": frappe.get_value("Customer", invoice.customer, "tax_id")
-        or None,
+        "customer_pin": customer_pin,
         "partner_name": frappe.get_value("Customer", invoice.customer, "customer_name")
         or None,
         "invoice_date": formatted_date,


### PR DESCRIPTION
build_invoice_payload() always pulled customer_pin from the Customer master, even though invoice.tax_id already exists and is already KRA-PIN-validated earlier in the submit flow. This made it impossible to send a different buyer PIN per invoice for walk-in customers.

Now the invoice's own tax_id is preferred, falling back to the Customer master's tax_id only when the invoice doesn't carry one.

Reproduced against a real submitted invoice on a test site: doc.tax_id  correctly held the per-transaction PIN after submit, but  build_invoice_payload(doc, settings_name) still returned customer_pin: None, since the shared walk-in Customer record's own PIN is blank. After this fix, the same call returns the invoice's PIN instead.